### PR TITLE
Update requirements

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -15,5 +15,6 @@ pytest-flake8
 pytest-xdist
 setuptools_scm
 sphinx
+toml
 twine
 wheel

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pyyaml
 requests
 jinja2
+toml


### PR DESCRIPTION
0.5.0 is failing on conda-forge build cause its lacking toml. seems like we may need an updated pypi release that lists toml