### PR TITLE
Pass str to subprocess calls

### DIFF
--- a/conda_lock/conda_lock.py
+++ b/conda_lock/conda_lock.py
@@ -168,7 +168,7 @@ def solve_specs_for_arch(
         conda,
         "create",
         "--prefix",
-        pathlib.Path(conda_pkgs_dir()).joinpath("prefix"),
+        os.path.join(conda_pkgs_dir(), "prefix"),
         "--dry-run",
         "--json",
     ]


### PR DESCRIPTION
https://github.com/conda-incubator/conda-lock/issues/52

With this change, generates successfully:
![image](https://user-images.githubusercontent.com/24661601/93487728-8c120300-f8d3-11ea-8db3-1472b76b5836.png)
