### PR TITLE
cast conda exec to string

### DIFF
--- a/conda_lock/conda_lock.py
+++ b/conda_lock/conda_lock.py
@@ -165,7 +165,7 @@ def solve_specs_for_arch(
     conda: PathLike, channels: Sequence[str], specs: List[str], platform: str
 ) -> dict:
     args: MutableSequence[PathLike] = [
-        conda,
+        str(conda),
         "create",
         "--prefix",
         os.path.join(conda_pkgs_dir(), "prefix"),
@@ -241,7 +241,7 @@ def search_for_md5s(conda: PathLike, package_specs: List[dict], platform: str):
         if name in found:
             continue
         out = subprocess.run(
-            [conda, "search", "--use-index-cache", "--json", spec],
+            [str(conda), "search", "--use-index-cache", "--json", spec],
             encoding="utf8",
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,


### PR DESCRIPTION
For some reason I missed this... or the conda executable sometimes just spuriously becomes a string / becomes a WindowsPath.

Here the conda.BAT exec for windows is a WindowsPath:
![image](https://user-images.githubusercontent.com/24661601/93640736-138d6e00-f9c9-11ea-81cc-f3e699651492.png)

with fix:
![image](https://user-images.githubusercontent.com/24661601/93640924-65ce8f00-f9c9-11ea-97ab-734927c01e7e.png)
