### PR TITLE
Add support for specifying conda dependencies in pyproject.toml

### DIFF
--- a/tests/test-flit/pyproject.toml
+++ b/tests/test-flit/pyproject.toml
@@ -21,3 +21,7 @@ build-backend = "flit_core.buildapi"
 channels = [
     'defaults'
 ]
+
+[tool.conda-lock.dependencies]
+sqlite = "<3.34"
+certifi = ">=2019.11.28"

--- a/tests/test-poetry/pyproject.toml
+++ b/tests/test-poetry/pyproject.toml
@@ -19,3 +19,7 @@ build-backend = "poetry.masonry.api"
 channels = [
     'defaults'
 ]
+
+[tool.conda-lock.dependencies]
+sqlite = "<3.34"
+certifi = ">=2019.11.28"

--- a/tests/test_conda_lock.py
+++ b/tests/test_conda_lock.py
@@ -105,6 +105,8 @@ def test_parse_poetry(poetry_pyproject_toml, include_dev_dependencies):
 
     assert "requests[version='>=2.13.0,<3.0.0']" in res.specs
     assert "toml[version='>=0.10']" in res.specs
+    assert "sqlite[version='<3.34']" in res.specs
+    assert "certifi[version='>=2019.11.28']" in res.specs
     assert ("pytest[version='>=5.1.0,<5.2.0']" in res.specs) == include_dev_dependencies
     assert res.channels == ["defaults"]
 
@@ -118,6 +120,8 @@ def test_parse_flit(flit_pyproject_toml, include_dev_dependencies):
 
     assert "requests[version='>=2.13.0']" in res.specs
     assert "toml[version='>=0.10']" in res.specs
+    assert "sqlite[version='<3.34']" in res.specs
+    assert "certifi[version='>=2019.11.28']" in res.specs
     # test deps
     assert ("pytest[version='>=5.1.0']" in res.specs) == include_dev_dependencies
     assert res.channels == ["defaults"]


### PR DESCRIPTION
Currently when locking from `pyproject.toml`, there is no way to constrain python dependencies (such as sqlite) that are added by the conda solver, which hurts reproducibility. Allowing the specification of arbitrary conda dependencies in pyproject.toml solves this problem and adds some additional flexibility.