### PR TITLE
Add env variable CONDA_FLAGS to pass additional flags to conda/mamba

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,20 +1,20 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v3.2.0
+  rev: v3.4.0
   hooks:
     - id: trailing-whitespace
     - id: check-ast
 
--   repo: https://gitlab.com/pycqa/flake8
-    rev: 3.8.3
-    hooks:
-    -   id: flake8
+- repo: https://gitlab.com/pycqa/flake8
+  rev: 3.8.4
+  hooks:
+    - id: flake8
 
-- repo: https://github.com/pre-commit/mirrors-isort
-  rev: v5.4.2
+- repo: https://github.com/pycqa/isort
+  rev: 5.7.0
   hooks:
   - id: isort
-    args: [--multi-line=3, --trailing-comma, --force-grid-wrap=0, --use-parentheses, --line-width=88]
+    args: ["--profile", "black", "--filter-files"]
 
 - repo: https://github.com/psf/black
   rev: 20.8b1
@@ -23,6 +23,6 @@ repos:
     language_version: python3
 
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v0.782
+  rev: v0.812
   hooks:
   - id: mypy

--- a/conda_lock/conda_lock.py
+++ b/conda_lock/conda_lock.py
@@ -8,6 +8,7 @@ import json
 import logging
 import os
 import pathlib
+import shlex
 import shutil
 import subprocess
 import sys
@@ -75,6 +76,9 @@ def solve_specs_for_arch(
         "--dry-run",
         "--json",
     ]
+    conda_flags = os.environ.get("CONDA_FLAGS")
+    if conda_flags:
+        args.extend(shlex.split(conda_flags))
     if channels:
         args.append("--override-channels")
     for channel in channels:
@@ -145,6 +149,9 @@ def do_conda_install(conda: PathLike, prefix: str, name: str, file: str) -> None
     if name:
         args.append("--name")
         args.append(name)
+    conda_flags = os.environ.get("CONDA_FLAGS")
+    if conda_flags:
+        args.extend(shlex.split(conda_flags))
 
     logging.debug("$MAMBA_ROOT_PREFIX: %s", os.environ.get("MAMBA_ROOT_PREFIX"))
     proc = subprocess.run(

--- a/tests/test_conda_lock.py
+++ b/tests/test_conda_lock.py
@@ -132,7 +132,7 @@ def test_parse_flit(flit_pyproject_toml, include_dev_dependencies):
 def test_run_lock(monkeypatch, zlib_environment, conda_exe):
     monkeypatch.chdir(zlib_environment.parent)
     if is_micromamba(conda_exe):
-        monkeypatch.setenv("CONDA_FLAGS", "-vv")
+        monkeypatch.setenv("CONDA_FLAGS", "-v")
     run_lock([zlib_environment], conda_exe=conda_exe)
 
 
@@ -233,7 +233,7 @@ def _check_package_installed(package: str, prefix: str):
 
 def test_install(tmp_path, conda_exe, zlib_environment, monkeypatch):
     if is_micromamba(conda_exe):
-        monkeypatch.setenv("CONDA_FLAGS", "-vv")
+        monkeypatch.setenv("CONDA_FLAGS", "-v")
 
     package = "zlib"
     platform = "linux-64"

--- a/tests/test_conda_lock.py
+++ b/tests/test_conda_lock.py
@@ -132,7 +132,7 @@ def test_parse_flit(flit_pyproject_toml, include_dev_dependencies):
 def test_run_lock(monkeypatch, zlib_environment, conda_exe):
     monkeypatch.chdir(zlib_environment.parent)
     if is_micromamba(conda_exe):
-        monkeypatch.setenv("CONDA_FLAGS", "-vvv")
+        monkeypatch.setenv("CONDA_FLAGS", "-vv")
     run_lock([zlib_environment], conda_exe=conda_exe)
 
 
@@ -233,7 +233,7 @@ def _check_package_installed(package: str, prefix: str):
 
 def test_install(tmp_path, conda_exe, zlib_environment, monkeypatch):
     if is_micromamba(conda_exe):
-        monkeypatch.setenv("CONDA_FLAGS", "-vvv")
+        monkeypatch.setenv("CONDA_FLAGS", "-vv")
 
     package = "zlib"
     platform = "linux-64"

--- a/tests/test_conda_lock.py
+++ b/tests/test_conda_lock.py
@@ -18,6 +18,7 @@ from conda_lock.conda_lock import (
     conda_env_override,
     create_lockfile_from_spec,
     determine_conda_executable,
+    is_micromamba,
     main,
     parse_meta_yaml_file,
     run_lock,
@@ -130,6 +131,8 @@ def test_parse_flit(flit_pyproject_toml, include_dev_dependencies):
 
 def test_run_lock(monkeypatch, zlib_environment, conda_exe):
     monkeypatch.chdir(zlib_environment.parent)
+    if is_micromamba(conda_exe):
+        monkeypatch.setenv("CONDA_FLAGS", "-vvv")
     run_lock([zlib_environment], conda_exe=conda_exe)
 
 
@@ -228,7 +231,10 @@ def _check_package_installed(package: str, prefix: str):
     return True
 
 
-def test_install(tmp_path, conda_exe, zlib_environment):
+def test_install(tmp_path, conda_exe, zlib_environment, monkeypatch):
+    if is_micromamba(conda_exe):
+        monkeypatch.setenv("CONDA_FLAGS", "-vvv")
+
     package = "zlib"
     platform = "linux-64"
 


### PR DESCRIPTION
Can be used to pass additional arguments to the conda/mamba invocations.

This allows for things like `export CONDA_FLAGS='-vvv'` to use to be able to diagnose issues.