### PR TITLE
Fix remove empty line in lock file

### DIFF
--- a/conda_lock/conda_lock.py
+++ b/conda_lock/conda_lock.py
@@ -568,9 +568,13 @@ def _strip_auth_from_lockfile(lockfile: str) -> str:
             if line != stripped_line
         }
     )
-    stripped_domains_doc = "\n".join(f"# - {domain}" for domain in stripped_domains)
     stripped_lockfile = "\n".join(stripped_lockfile_lines)
-    return f"# The following domains require authentication:\n{stripped_domains_doc}\n{stripped_lockfile}\n"
+    if lockfile.endswith("\n"):
+        stripped_lockfile += "\n"
+    if stripped_domains:
+        stripped_domains_doc = "\n".join(f"# - {domain}" for domain in stripped_domains)
+        return f"# The following domains require authentication:\n{stripped_domains_doc}\n{stripped_lockfile}"
+    return stripped_lockfile
 
 
 def run_lock(

--- a/tests/test-lockfile/no-auth.lock
+++ b/tests/test-lockfile/no-auth.lock
@@ -1,0 +1,3 @@
+http://a.mychannel.cloud/mypackage
+http://b.mychannel.cloud/mypackage
+http://c.mychannel.cloud/mypackage

--- a/tests/test-stripped-lockfile/no-auth.lock
+++ b/tests/test-stripped-lockfile/no-auth.lock
@@ -1,0 +1,3 @@
+http://a.mychannel.cloud/mypackage
+http://b.mychannel.cloud/mypackage
+http://c.mychannel.cloud/mypackage

--- a/tests/test_conda_lock.py
+++ b/tests/test_conda_lock.py
@@ -350,7 +350,7 @@ def _read_file(filepath):
                 .joinpath(f"{filename}.lock")
             ),
         )
-        for filename in ("test",)
+        for filename in ("test", "no-auth")
     ),
 )
 def test__strip_auth_from_lockfile(lockfile, stripped_lockfile):


### PR DESCRIPTION
Closes #87 

The `The following domains require authentication` docstring now only shows up if there is a least one domain with it's basic auth stripped.