### PR TITLE
Add --auth arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ is being built from support them).  This can be disabled easily
 conda-lock --no-dev-dependencies -f ./recipe/meta.yaml
 ```
 
-#### --strip-auth and --auth-file
+#### --strip-auth, --auth and --auth-file
 
 By default `conda-lock` will leave basic auth credentials for private conda channels in the lock file. If you wish to strip authentication from the file, provide the `--strip-auth` argument.
 
@@ -95,7 +95,7 @@ In order to `conda-lock install` a lock file with its basic auth credentials str
 }
 ```
 
-Then, you need to provide the path to the authentication file through the `--auth-file` argument.
+You can provide the authentication either as string through `--auth` or as a filepath through `--auth-file`.
 
 ```
 conda-lock install --auth-file auth.json conda-linux-64.lock

--- a/conda_lock/conda_lock.py
+++ b/conda_lock/conda_lock.py
@@ -728,11 +728,16 @@ def lock(
 )
 @click.option("-p", "--prefix", help="Full path to environment location (i.e. prefix).")
 @click.option("-n", "--name", help="Name of environment.")
+@click.option(
+    "--auth",
+    help="The auth file provided as string. Has precedence over `--auth-file`.",
+    default="",
+)
 @click.option("--auth-file", help="Path to the authentication file.", default="")
 @click.argument("lock-file")
-def install(conda, mamba, micromamba, prefix, name, lock_file, auth_file):
+def install(conda, mamba, micromamba, prefix, name, lock_file, auth, auth_file):
     """Perform a conda install"""
-    auth = read_json(auth_file) if auth_file else None
+    auth = json.loads(auth) if auth else read_json(auth_file) if auth_file else None
     _conda_exe = determine_conda_executable(conda, mamba=mamba, micromamba=micromamba)
     install_func = partial(do_conda_install, conda=_conda_exe, prefix=prefix, name=name)
     if auth:


### PR DESCRIPTION
I noticed that the `--auth-file` argument can be a bit inconvenient sometimes, because you need to store the authentication in a file. This makes using conda-lock in Docker builds less fun, because you need to copy the file into the build and also make sure to delete it after installing the requirements. It's also inconvenient in CI pipelines.

I've introduced the `--auth` argument for `conda-lock install`, which works the same way as `--auth-file` but accepts an auth string instead of a file path to an auth file. I also thought it should have precedence over `--auth-file`.

Let me know what you think about this possible addition to the project. :)