### PR TITLE
Add selectors that match osx-arm64 (arm64, osx, unix)

### DIFF
--- a/conda_lock/src_parser/selectors.py
+++ b/conda_lock/src_parser/selectors.py
@@ -11,6 +11,7 @@ def filter_platform_selectors(content: str, platform) -> Iterator[str]:
         "linux-aarch64": {"aarch64", "unix", "linux"},
         "linux-ppc64le": {"ppc64le", "unix", "linux"},
         "osx-64": {"osx", "osx64", "unix"},
+        "osx-arm64": {"arm64", "osx", "unix"},
         "win-64": {"win", "win64"},
     }
 


### PR DESCRIPTION
Currently, the use of any selectors fails when creating a lockfile for osx-arm64 (or any platform that's not listed here). Adding osx-arm64 selectors is the simplest fix, although a more general solution that gracefully handles new platforms would obviously be desirable. At least this brings the list up to parity for what conda-forge currently builds for.