### PR TITLE
Sort lockfile entries by package name

### DIFF
--- a/conda_lock/conda_lock.py
+++ b/conda_lock/conda_lock.py
@@ -6,6 +6,7 @@ import atexit
 import datetime
 import json
 import logging
+from operator import itemgetter
 import os
 import pathlib
 import re
@@ -459,7 +460,7 @@ def create_lockfile_from_spec(
     ]
 
     if kind == "env":
-        link_actions = dry_run_install["actions"]["LINK"]
+        link_actions = sorted(dry_run_install["actions"]["LINK"], key=itemgetter("name"))
         lockfile_contents.extend(
             [
                 "channels:",
@@ -474,7 +475,7 @@ def create_lockfile_from_spec(
     elif kind == "explicit":
         lockfile_contents.append("@EXPLICIT\n")
 
-        link_actions = dry_run_install["actions"]["LINK"]
+        link_actions = sorted(dry_run_install["actions"]["LINK"], key=itemgetter("name"))
         for link in link_actions:
             if is_micromamba(conda):
                 link["url_base"] = fn_to_dist_name(link["url"])


### PR DESCRIPTION
First of all, thanks for providing this great tool! Combined with micromamba it has made deploying python apps a much nicer experience.

One small bother I've had is the non-deterministic ordering of packages in the lockfiles produced by conda-lock. If I modify my requirements and then re-run conda-lock, I'd like to be able to quickly glance at the diff as a sanity check; but even if only one package has actually changed, the re-ordering will make the diff huge.

This PR solves this by sorting the packages by name before outputting them to the lockfile.

My understanding of conda is very limited, so I'm not 100% sure the order of packages in the lockfile isn't important - please enlighten me and reject the PR if it is!