### PR TITLE
Fix regression for multi-platform lock

### DIFF
--- a/conda_lock/conda_lock.py
+++ b/conda_lock/conda_lock.py
@@ -373,7 +373,7 @@ def make_lock_specs(
         else:
             channels = lock_spec.channels
         lock_spec.channels = channels
-        res[sys.platform] = lock_spec
+        res[plat] = lock_spec
     return res
 
 


### PR DESCRIPTION
Regression was  introduced in 9aa90dc0b12c49785e912a1f87bfe38762e89058: `make_lock_specs` would write all resolved specs to the key `sys.platform`.
This results in only the first platform being processed. There are no error messages and only hint of something being amiss is that logging reports the lockfile being built for the value of `sys.platform` instead of the actual platform.