### PR TITLE
Small bugfix for error handling code

### DIFF
--- a/conda_lock/conda_lock.py
+++ b/conda_lock/conda_lock.py
@@ -196,7 +196,7 @@ def solve_specs_for_arch(
     def print_proc(proc):
         import shlex
 
-        print(f"    Command: {' '.join(shlex.quote(x) for x in proc.args)}")
+        print(f"    Command: {' '.join(shlex.quote(str(x)) for x in proc.args)}")
         if proc.stdout:
             print(f"    STDOUT:\n{proc.stdout}")
         if proc.stderr:


### PR DESCRIPTION
Closes #119 

Per the issue description:
If the Conda subprocess in solve_specs_for_arch() encounters an error and produces a non-zero return code, error handling code in the inner function print_proc() will fail while printing the arguments used for the Conda subprocess.

This is because shlex.quote() does not coerce the objects it receives to string.

The first item in the Conda subprocess arguments is a PosixPath object, and therefore needs to be converted to a string before being passed to shlex.quote()