### PR TITLE
Allow to pass different credentials for different channels in same domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,15 @@ In order to `conda-lock install` a lock file with its basic auth credentials str
 }
 ```
 
+If you have multiple channels that require different authentication within the same domain, you can additionally specify the channel like this:
+
+```json
+{
+  "domain.org/channel1": "username1:password1",
+  "domain.org/channel2": "username2:password2"
+}
+```
+
 You can provide the authentication either as string through `--auth` or as a filepath through `--auth-file`.
 
 ```bash

--- a/conda_lock/conda_lock.py
+++ b/conda_lock/conda_lock.py
@@ -773,10 +773,16 @@ def determine_conda_executable(
 
 
 def _add_auth_to_line(line: str, auth: Dict[str, str]):
-    search = DOMAIN_PATTERN.search(line)
-    if search and search.group(2) in auth:
-        return f"{search.group(1)}{auth[search.group(2)]}@{search.group(2)}{search.group(3)}"
-    return line
+    matching_auths = [a for a in auth if a in line]
+    # TODO: Currently assuming this it at most one.
+    if not matching_auths:
+        return line
+    if len(matching_auths) == 1:
+        matching_auth = matching_auths[0]
+        replacement = f"{auth[matching_auth]}@{matching_auth}"
+        return line.replace(matching_auth, replacement)
+    else:
+        raise RuntimeError(f"More than one matching auth: {matching_auths}")
 
 
 def _add_auth_to_lockfile(lockfile: str, auth: Dict[str, str]) -> str:

--- a/conda_lock/conda_lock.py
+++ b/conda_lock/conda_lock.py
@@ -774,15 +774,12 @@ def determine_conda_executable(
 
 def _add_auth_to_line(line: str, auth: Dict[str, str]):
     matching_auths = [a for a in auth if a in line]
-    # TODO: Currently assuming this it at most one.
     if not matching_auths:
         return line
-    if len(matching_auths) == 1:
-        matching_auth = matching_auths[0]
-        replacement = f"{auth[matching_auth]}@{matching_auth}"
-        return line.replace(matching_auth, replacement)
-    else:
-        raise RuntimeError(f"More than one matching auth: {matching_auths}")
+    # If we have multiple matching auths, we choose the longest one.
+    matching_auth = max(matching_auths, key=len)
+    replacement = f"{auth[matching_auth]}@{matching_auth}"
+    return line.replace(matching_auth, replacement)
 
 
 def _add_auth_to_lockfile(lockfile: str, auth: Dict[str, str]) -> str:

--- a/tests/test_conda_lock.py
+++ b/tests/test_conda_lock.py
@@ -480,6 +480,14 @@ def test__strip_auth_from_lockfile(lockfile, stripped_lockfile):
             {"conda.mychannel.cloud/channel1": "username:password"},
             "https://username:password@conda.mychannel.cloud/channel1/mypackage",
         ),
+        (
+            "https://conda.mychannel.cloud/channel1/mypackage",
+            {
+                "conda.mychannel.cloud": "username:password",
+                "conda.mychannel.cloud/channel1": "username1:password1",
+            },
+            "https://username1:password1@conda.mychannel.cloud/channel1/mypackage",
+        ),
     ),
 )
 def test__add_auth_to_line(line, auth, line_with_auth):

--- a/tests/test_conda_lock.py
+++ b/tests/test_conda_lock.py
@@ -6,7 +6,7 @@ import shutil
 import subprocess
 import sys
 
-from typing import Any, Dict, MutableSequence
+from typing import Any, MutableSequence
 
 import pytest
 

--- a/tests/test_conda_lock.py
+++ b/tests/test_conda_lock.py
@@ -6,7 +6,7 @@ import shutil
 import subprocess
 import sys
 
-from typing import Any, MutableSequence
+from typing import Any, Dict, MutableSequence
 
 import pytest
 
@@ -474,6 +474,11 @@ def test__strip_auth_from_lockfile(lockfile, stripped_lockfile):
             "https://conda.mychannel.cloud/mypackage",
             {},
             "https://conda.mychannel.cloud/mypackage",
+        ),
+        (
+            "https://conda.mychannel.cloud/channel1/mypackage",
+            {"conda.mychannel.cloud/channel1": "username:password"},
+            "https://username:password@conda.mychannel.cloud/channel1/mypackage",
         ),
     ),
 )


### PR DESCRIPTION
When we first implement the feature to strip auths from lock files and later provide auth during the installation, we didn't consider the case, where different channels in the same domain require different auths.

Example:

`http://mydomain.org/mychannel1` requires the following auth: `username1:password1`
`http://mydomain.org/mychannel2` requires the following auth: `username2:password2`

This is something you weren't able to express until now because you were limited to providing one auth per domain.