### PR TITLE
Refactor lookup

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
           pushd "${RUNNER_TEMP}"
           set TMPDIR="%RUNNER_TEMP%"
           dir
-          pytest -n auto --showlocals -vrsx --cov=conda_lock tests
+          pytest -n auto -vrsx --cov=conda_lock tests
 
   test:
     runs-on: ${{ matrix.os }}
@@ -91,7 +91,7 @@ jobs:
           ls -lah
           set -x
           which pytest
-          pytest -n auto --showlocals -vvrsx --cov=conda_lock tests
+          pytest -n auto -vrsx --cov=conda_lock tests
 
       - name: test-gdal
         shell: bash -l {0}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,4 +26,4 @@ repos:
   rev: v0.910
   hooks:
   - id: mypy
-    additional_dependencies: [types-requests, types-toml, types-PyYAML, types-setuptools, pydantic]
+    additional_dependencies: [types-filelock, types-requests, types-toml, types-PyYAML, types-setuptools, pydantic]

--- a/conda_lock/conda_lock.py
+++ b/conda_lock/conda_lock.py
@@ -279,7 +279,19 @@ def make_lock_files(
         platforms_to_lock: List[str] = []
         platforms_already_locked: List[str] = []
         if lockfile_path.exists():
-            lock_content = parse_conda_lock_file(lockfile_path)
+            import yaml
+
+            try:
+                lock_content = parse_conda_lock_file(lockfile_path)
+            except (yaml.error.YAMLError, FileNotFoundError):
+                logger.warning(
+                    "Failed to parse existing lock.  Regenerating from scratch"
+                )
+                lock_content = None
+        else:
+            lock_content = None
+
+        if lock_content is not None:
             platforms_already_locked = list(lock_content.metadata.platforms)
             update_spec = UpdateSpecification(
                 locked=lock_content.package, update=update

--- a/conda_lock/conda_lock.py
+++ b/conda_lock/conda_lock.py
@@ -255,7 +255,7 @@ def make_lock_files(
     extras :
         Include the given extras in explicit or env output
     check_input_hash :
-        Do not re-solve for each target platform for which specifcations are unchanged
+        Do not re-solve for each target platform for which specifications are unchanged
     """
 
     # initialize virtual package fake
@@ -359,7 +359,7 @@ def do_render(
     extras :
         Include the given extras in output
     check_input_hash :
-        Do not re-render if specifcations are unchanged
+        Do not re-render if specifications are unchanged
 
     """
 

--- a/conda_lock/conda_lock.py
+++ b/conda_lock/conda_lock.py
@@ -241,7 +241,7 @@ def make_lock_files(
         Path to a conda-lock.yml to create or update
     platform_overrides :
         Platforms to solve for. Takes precedence over platforms found in src_files.
-    channels_overrides :
+    channel_overrides :
         Channels to use. Takes precedence over channels found in src_files.
     virtual_package_spec :
         Path to a virtual package repository that defines each platform.

--- a/conda_lock/conda_solver.py
+++ b/conda_lock/conda_solver.py
@@ -163,7 +163,10 @@ def solve_conda(
     }
 
     # propagate categories from explicit to transitive dependencies
-    _apply_categories({k: v for k, v in specs.items() if v.manager == "conda"}, planned)
+    _apply_categories(
+        requested={k: v for k, v in specs.items() if v.manager == "conda"},
+        planned=planned,
+    )
 
     return planned
 

--- a/conda_lock/lookup.py
+++ b/conda_lock/lookup.py
@@ -1,0 +1,35 @@
+from typing import Dict, Optional
+
+import requests
+import yaml
+
+
+PYPI_LOOKUP: Optional[Dict] = None
+
+# TODO: make this configurable
+PYPI_TO_CONDA_NAME_LOOKUP = "https://raw.githubusercontent.com/regro/cf-graph-countyfair/master/mappings/pypi/grayskull_pypi_mapping.yaml"
+
+
+def get_forward_lookup():
+    global PYPI_LOOKUP
+    if PYPI_LOOKUP is None:
+        res = requests.get(PYPI_TO_CONDA_NAME_LOOKUP)
+        res.raise_for_status()
+        PYPI_LOOKUP = yaml.safe_load(res.content)
+    return PYPI_LOOKUP
+
+
+def get_lookup() -> Dict:
+    """
+    Reverse grayskull name mapping to map conda names onto PyPI
+    """
+    global PYPI_LOOKUP
+    if PYPI_LOOKUP is None:
+        PYPI_LOOKUP = {
+            record["conda_name"]: record for record in get_forward_lookup().values()
+        }
+    return PYPI_LOOKUP
+
+
+def normalize_conda_name(name: str):
+    return get_lookup().get(name, {"pypi_name": name})["pypi_name"]

--- a/conda_lock/lookup.py
+++ b/conda_lock/lookup.py
@@ -5,12 +5,13 @@ import yaml
 
 
 PYPI_LOOKUP: Optional[Dict] = None
+CONDA_LOOKUP: Optional[Dict] = None
 
 # TODO: make this configurable
 PYPI_TO_CONDA_NAME_LOOKUP = "https://raw.githubusercontent.com/regro/cf-graph-countyfair/master/mappings/pypi/grayskull_pypi_mapping.yaml"
 
 
-def get_forward_lookup():
+def get_forward_lookup() -> Dict:
     global PYPI_LOOKUP
     if PYPI_LOOKUP is None:
         res = requests.get(PYPI_TO_CONDA_NAME_LOOKUP)
@@ -23,13 +24,20 @@ def get_lookup() -> Dict:
     """
     Reverse grayskull name mapping to map conda names onto PyPI
     """
-    global PYPI_LOOKUP
-    if PYPI_LOOKUP is None:
-        PYPI_LOOKUP = {
+    global CONDA_LOOKUP
+    if CONDA_LOOKUP is None:
+        CONDA_LOOKUP = {
             record["conda_name"]: record for record in get_forward_lookup().values()
         }
-    return PYPI_LOOKUP
+    return CONDA_LOOKUP
 
 
-def normalize_conda_name(name: str):
-    return get_lookup().get(name, {"pypi_name": name})["pypi_name"]
+def conda_name_to_pypi_name(name: str) -> str:
+    """return the pypi name for a conda package"""
+    lookup = get_lookup()
+    return lookup.get(name, {"pypi_name": name})["pypi_name"]
+
+
+def pypi_name_to_conda_name(name: str) -> str:
+    """return the conda name for a pypi package"""
+    return get_forward_lookup().get(name, {"conda_name": name})["conda_name"]

--- a/conda_lock/pypi_solver.py
+++ b/conda_lock/pypi_solver.py
@@ -18,7 +18,7 @@ from poetry.repositories.repository import Repository
 from poetry.utils.env import Env
 
 from conda_lock import src_parser
-from conda_lock.src_parser.pyproject_toml import get_lookup as get_forward_lookup
+from conda_lock.lookup import normalize_conda_name
 
 
 # NB: in principle these depend on the glibc in the conda env
@@ -154,25 +154,6 @@ def get_package(locked: src_parser.LockedDependency) -> Package:
         )
     else:
         return Package(locked.name, version=locked.version)
-
-
-PYPI_LOOKUP: Optional[Dict] = None
-
-
-def get_lookup() -> Dict:
-    """
-    Reverse grayskull name mapping to map conda names onto PyPI
-    """
-    global PYPI_LOOKUP
-    if PYPI_LOOKUP is None:
-        PYPI_LOOKUP = {
-            record["conda_name"]: record for record in get_forward_lookup().values()
-        }
-    return PYPI_LOOKUP
-
-
-def normalize_conda_name(name: str):
-    return get_lookup().get(name, {"pypi_name": name})["pypi_name"]
 
 
 def solve_pypi(

--- a/conda_lock/pypi_solver.py
+++ b/conda_lock/pypi_solver.py
@@ -204,7 +204,7 @@ def solve_pypi(
         if dep.name.startswith("__"):
             continue
         try:
-            pypi_name = conda_name_to_pypi_name(dep.name)
+            pypi_name = conda_name_to_pypi_name(dep.name).lower()
         except KeyError:
             continue
         # Prefer the Python package when its name collides with the Conda package
@@ -287,7 +287,7 @@ def solve_pypi(
 
     for conda_name, dep in conda_locked.items():
         try:
-            pypi_name = conda_name_to_pypi_name(conda_name)
+            pypi_name = conda_name_to_pypi_name(conda_name).lower()
         except KeyError:
             # no conda-name found, assuming conda packages do NOT intersect with the pip package
             continue

--- a/conda_lock/src_parser/__init__.py
+++ b/conda_lock/src_parser/__init__.py
@@ -20,6 +20,7 @@ from typing import (
 from pydantic import BaseModel, Field, validator
 
 from conda_lock.common import ordered_union
+from conda_lock.lookup import normalize_conda_name
 from conda_lock.virtual_package import FakeRepoData
 
 
@@ -243,7 +244,7 @@ def _apply_categories(
     def seperator_munge_get(
         d: Dict[str, LockedDependency], key: str
     ) -> LockedDependency:
-        # since seperators are not consistent across managers we need to do some double attemps here
+        # since separators are not consistent across managers we need to do some double attempts here
         try:
             return d[key]
         except KeyError:
@@ -287,7 +288,7 @@ def _apply_categories(
 
     for dep, root in root_requests.items():
         source = requested[root]
-        target = seperator_munge_get(planned, dep)
+        target = seperator_munge_get(planned, normalize_conda_name(dep).lower())
         target.category = source.category
         target.optional = source.optional
 

--- a/conda_lock/src_parser/__init__.py
+++ b/conda_lock/src_parser/__init__.py
@@ -179,13 +179,13 @@ class Lockfile(StrictModel):
 
                 ordered = toposort(lookup)
                 for package_name in ordered:
-                    d = packages[package_name]                 
+                    d = packages[package_name]
                     if d.manager != manager:
                         continue
                     # skip virtual packages
                     if d.manager == "conda" and d.name.startswith("__"):
                         continue
-                        
+
                     final_package.append(d)
 
         return Lockfile(package=final_package, metadata=other.metadata | self.metadata)

--- a/conda_lock/src_parser/__init__.py
+++ b/conda_lock/src_parser/__init__.py
@@ -179,14 +179,18 @@ class Lockfile(StrictModel):
 
                 ordered = toposort(lookup)
                 for package_name in ordered:
-                    d = packages[package_name]
-                    if d.manager != manager:
+                    # since we could have a pure dep in here, that does not have a package
+                    # eg a pip package that depends on a conda package (the conda package will not be in this list)
+                    dep = packages.get(package_name)
+                    if dep is None:
+                        continue
+                    if dep.manager != manager:
                         continue
                     # skip virtual packages
-                    if d.manager == "conda" and d.name.startswith("__"):
+                    if dep.manager == "conda" and dep.name.startswith("__"):
                         continue
 
-                    final_package.append(d)
+                    final_package.append(dep)
 
         return Lockfile(package=final_package, metadata=other.metadata | self.metadata)
 

--- a/conda_lock/src_parser/__init__.py
+++ b/conda_lock/src_parser/__init__.py
@@ -5,17 +5,7 @@ import pathlib
 from collections import defaultdict, namedtuple
 from dataclasses import dataclass
 from itertools import chain
-from typing import (
-    ClassVar,
-    Dict,
-    List,
-    Literal,
-    NamedTuple,
-    Optional,
-    Sequence,
-    Set,
-    Tuple,
-)
+from typing import ClassVar, Dict, List, Literal, Optional, Sequence, Set, Tuple
 
 from pydantic import BaseModel, Field, validator
 

--- a/conda_lock/src_parser/pyproject_toml.py
+++ b/conda_lock/src_parser/pyproject_toml.py
@@ -6,31 +6,16 @@ from functools import partial
 from typing import AbstractSet, Any, List, Literal, Mapping, Optional, Sequence
 from urllib.parse import urldefrag
 
-import requests
 import toml
-import yaml
 
 from conda_lock.common import get_in
+from conda_lock.lookup import get_forward_lookup as get_lookup
 from conda_lock.src_parser import (
     Dependency,
     LockSpecification,
     URLDependency,
     VersionedDependency,
 )
-
-
-# TODO: make this configurable
-PYPI_TO_CONDA_NAME_LOOKUP = "https://raw.githubusercontent.com/regro/cf-graph-countyfair/master/mappings/pypi/grayskull_pypi_mapping.yaml"
-PYPI_LOOKUP: Optional[dict] = None
-
-
-def get_lookup():
-    global PYPI_LOOKUP
-    if PYPI_LOOKUP is None:
-        res = requests.get(PYPI_TO_CONDA_NAME_LOOKUP)
-        res.raise_for_status()
-        PYPI_LOOKUP = yaml.safe_load(res.content)
-    return PYPI_LOOKUP
 
 
 def join_version_components(pieces):
@@ -116,7 +101,7 @@ def parse_poetry_pyproject_toml(
                 url = depattrs.get("url", None)
                 optional = depattrs.get("optional", False)
                 extras = depattrs.get("extras", [])
-                # If a depdendency is explicitly marked as sourced from pypi,
+                # If a dependency is explicitly marked as sourced from pypi,
                 # or is a URL dependency, delegate to the pip section
                 if (
                     depattrs.get("source", None) == "pypi"

--- a/conda_lock/virtual_package.py
+++ b/conda_lock/virtual_package.py
@@ -113,7 +113,7 @@ class FakeRepoData:
         logger.debug("repo: %s", self.channel_url)
 
     def __enter__(self):
-        """Ensure that if glibc etc is set by the overrides we force the conda solver overrride variables"""
+        """Ensure that if glibc etc is set by the overrides we force the conda solver override variables"""
         env_vars_to_clear = set()
         for package in self.packages_by_subdir:
             if package.name.startswith("__"):

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,7 @@
 black
 check-manifest
 doctr
+filelock
 flake8
 flake8-builtins
 flake8-comprehensions

--- a/tests/test-pypi-resolve-namediff/environment.yml
+++ b/tests/test-pypi-resolve-namediff/environment.yml
@@ -2,7 +2,7 @@ channels:
   - conda-forge
 dependencies:
   - python=3.9
-  - dask
+  - dask-core
   - pip
   - pip:
       - geogif  # brings in dask and chokes with dask(-/_)core name in conda-forge

--- a/tests/test-pypi-resolve/environment-different-names-same-deps.yml
+++ b/tests/test-pypi-resolve/environment-different-names-same-deps.yml
@@ -1,0 +1,8 @@
+channels:
+  - conda-forge
+dependencies:
+  - python=3.9
+  - dask
+  - pip
+  - pip:
+      - geogif  # brings in dask and chokes with dask(-/_)core name in conda-forge

--- a/tests/test_conda_lock.py
+++ b/tests/test_conda_lock.py
@@ -75,6 +75,13 @@ def pip_environment():
 
 
 @pytest.fixture
+def pip_environment_different_names_same_deps():
+    return TEST_DIR.joinpath("test-pypi-resolve").joinpath(
+        "environment-different-names-same-deps.yml"
+    )
+
+
+@pytest.fixture
 def pip_local_package_environment():
     return TEST_DIR.joinpath("test-local-pip").joinpath("environment.yml")
 

--- a/tests/test_conda_lock.py
+++ b/tests/test_conda_lock.py
@@ -76,9 +76,12 @@ def pip_environment():
 
 @pytest.fixture
 def pip_environment_different_names_same_deps():
-    return TEST_DIR.joinpath("test-pypi-resolve").joinpath(
-        "environment-different-names-same-deps.yml"
-    )
+    root = TEST_DIR.joinpath("test-pypi-resolve-namediff")
+    envfile = root.joinpath("environment.yml")
+    yield envfile
+    # for child in root.iterdir():
+    #     if child != envfile:
+    #         child.unlink()
 
 
 @pytest.fixture

--- a/tests/test_conda_lock.py
+++ b/tests/test_conda_lock.py
@@ -385,6 +385,15 @@ def test_run_lock_with_pip(monkeypatch, pip_environment, conda_exe):
     run_lock([pip_environment], conda_exe=conda_exe)
 
 
+def test_run_lock_with_pip_environment_different_names_same_deps(
+    monkeypatch, pip_environment_different_names_same_deps, conda_exe
+):
+    monkeypatch.chdir(pip_environment_different_names_same_deps.parent)
+    if is_micromamba(conda_exe):
+        monkeypatch.setenv("CONDA_FLAGS", "-v")
+    run_lock([pip_environment_different_names_same_deps], conda_exe=conda_exe)
+
+
 def test_run_lock_with_local_package(
     monkeypatch, pip_local_package_environment, conda_exe
 ):


### PR DESCRIPTION
I found an odd bug when using the latest dev version with pip support. If one have an environment with pip dependencies that installs a conda dependency with a name that doesn't match PyPI, like:

```yaml
name: test
channels:
  - conda-forge
dependencies:
  - python=3.10
  - dask
  - pip
  - pip: 
      - geogif  # brings in dask, that is in the env file too
```

The problem is that the error doesn't happen all the time and it is really frustrating trying to figure out why. Maybe the differences in the solver results from one run to another?. @mariusvniekerk, if you have some time I'd love to hear your thought on this.

Here is the error when it happens:

```
❯ conda-lock --conda=mamba -f environment.yaml -p linux-64
During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "conda-lock/conda_lock/src_parser/__init__.py", line 251, in seperator_munge_get
    return d[key.replace("-", "_")]
KeyError: 'dask_core'

During handling of the above exception, another exception occurred:
```

This PR factors out some of the logic for the lookups so we can import them in multiple places avoiding circular imports. I needed that to use `normalize_conda_name` in multiple places. With that change the error never happens but I'm not confident this is the best solution.