### PR TITLE
For selector filtering require selectors to be commented

### DIFF
--- a/conda_lock/src_parser/selectors.py
+++ b/conda_lock/src_parser/selectors.py
@@ -1,6 +1,10 @@
+import logging
 import re
 
 from typing import Iterator
+
+
+logger = logging.getLogger(__name__)
 
 
 def filter_platform_selectors(content: str, platform) -> Iterator[str]:
@@ -23,7 +27,11 @@ def filter_platform_selectors(content: str, platform) -> Iterator[str]:
         m = sel_pat.match(line)
         if m:
             cond = m.group(3)
-            if cond in platform_sel[platform]:
+            if platform and (cond in platform_sel[platform]):
                 yield line
+            else:
+                logger.warning(
+                    "filtered out line `%s` due to unmatchable selector", line
+                )
         else:
             yield line


### PR DESCRIPTION
Conda meta.yaml selectors can take the form

```yaml
  - foo [linux]
```

instead of the more usual

```yaml
  - foo  # [linux]
```
which is basically entirely crazy.  Conda-lock will deviate from conda here by requiring selectors to be comments as they are in almost 100% of recipes