### PR TITLE
Channel order should now be preserved properly.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,13 +2,13 @@ exclude: ^conda_lock/vendor/.*$
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.0.1
+  rev: v4.1.0
   hooks:
     - id: trailing-whitespace
     - id: check-ast
 
 - repo: https://github.com/psf/black
-  rev: 21.8b0
+  rev: 22.1.0
   hooks:
   - id: black
     language_version: python3
@@ -19,13 +19,13 @@ repos:
     - id: flake8
 
 - repo: https://github.com/pycqa/isort
-  rev: 5.9.3
+  rev: 5.10.1
   hooks:
   - id: isort
     args: ["--profile", "black", "--filter-files"]
 
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v0.910
+  rev: v0.931
   hooks:
   - id: mypy
     additional_dependencies: [types-filelock, types-requests, types-toml, types-PyYAML, types-setuptools, pydantic]

--- a/conda_lock/common.py
+++ b/conda_lock/common.py
@@ -1,10 +1,15 @@
 import json
 import os
 import pathlib
+import typing
 
 from itertools import chain
 from typing import Any, Dict, Iterable, List, Mapping, Sequence, TypeVar, Union
 
+
+if typing.TYPE_CHECKING:
+    # Not in the release version of typeshed yet
+    from _typeshed import SupportsRichComparisonT  # type: ignore
 
 T = TypeVar("T")
 
@@ -45,6 +50,40 @@ def read_json(filepath: Union[str, pathlib.Path]) -> Dict:
 
 def ordered_union(collections: Iterable[Iterable[T]]) -> List[T]:
     return list({k: k for k in chain.from_iterable(collections)}.values())
+
+
+def suffix_union(
+    collections: Iterable[Sequence["SupportsRichComparisonT"]],
+) -> List["SupportsRichComparisonT"]:
+    """Generates the union of sequence ensuring that they have a common suffix.
+
+    This is used to unify channels.
+
+    >>> suffix_union([[1], [2, 1], [3, 2, 1], [2, 1], [1]])
+    [3, 2, 1]
+
+    >>> suffix_union([[1], [2, 1], [4, 1]])
+    Traceback (most recent call last)
+        ...
+    RuntimeError: [4, 1] is not a subset of [2, 1]
+
+    """
+    from genericpath import commonprefix
+
+    result: List["SupportsRichComparisonT"] = []
+    for seq in collections:
+        if seq:
+            rev_priority = list(reversed(seq))
+            prefix = commonprefix([result, rev_priority])  # type: ignore
+            if len(result) == 0:
+                result = rev_priority
+            elif prefix[: len(rev_priority)] != result[: len(rev_priority)]:
+                raise ValueError(
+                    f"{list(reversed(rev_priority))} is not a ordered subset of {list(reversed(result))}"
+                )
+            elif len(rev_priority) > len(result):
+                result = rev_priority
+    return list(reversed(result))
 
 
 def relative_path(source: pathlib.Path, target: pathlib.Path) -> str:

--- a/conda_lock/conda_lock.py
+++ b/conda_lock/conda_lock.py
@@ -17,6 +17,7 @@ from functools import partial
 from types import TracebackType
 from typing import (
     AbstractSet,
+    Any,
     Dict,
     Iterator,
     List,
@@ -1306,8 +1307,8 @@ def render(
 def _handle_exception_post_mortem(
     exc_type: Type[BaseException],
     exc_value: BaseException,
-    exc_traceback: TracebackType,
-) -> None:
+    exc_traceback: Optional[TracebackType],
+) -> Any:
     import pdb
 
     pdb.post_mortem(exc_traceback)

--- a/conda_lock/errors.py
+++ b/conda_lock/errors.py
@@ -15,3 +15,9 @@ class MissingEnvVarError(CondaLockError):
     """
     Error thrown if env vars are missing in channel urls.
     """
+
+
+class ChannelAggregationError(CondaLockError):
+    """
+    Error thrown when lists of channels cannot be combined
+    """


### PR DESCRIPTION
Previously it was somewhat arbitrary what happened.  This ensures that behavior that happens is what we should largely expect.

Channel merging REQUIRES that order be maintained.  Since determining the order when merging say `['pytorch', 'defaults']` and `['conda-forge', 'defaults']` is impossible to determine we raise.