### PR TITLE
Add --filter-categories

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,12 @@ conda-lock --extra mysql --extra pgsql -f pyproject.toml
 
 When generating lockfiles that make use of extras it is recommended to make use of `--filename-template` covered [here](#file-naming).
 
+##### Filtering extras
+
+ By default conda-lock will attempt to solve for *ALL* extras/categories it discovers in sources.  This allows you to render explicit locks with subset of extras, without needing a new solve.
+
+
+
 #### Extra conda dependencies
 
 Since in a `pyproject.toml` all the definitions are python dependencies if you need
@@ -328,7 +334,6 @@ the following sections to the `pyproject.toml`
 [tool.conda-lock.dependencies]
 sqlite = ">=3.34"
 ```
-
 #### pip dependencies
 
 If a dependency refers directly to a URL rather than a package name and version,

--- a/docs/flags.md
+++ b/docs/flags.md
@@ -86,6 +86,33 @@ conda-lock --no-dev-dependencies --file ./recipe/meta.yaml
 
 ---
 
+## --extras or --categories
+
+If your source files contains optional dependencies/extras these can be included in the output of a `render` by using the
+flag.
+
+```sh
+conda-lock --extra mysql --extra pgsql -f pyproject.toml
+```
+
+When generating lockfiles that make use of extras it is recommended to make use of `--filename-template` covered [here](#file-naming).
+
+!!! note ""
+
+    By default conda-lock will attempt to solve for *ALL* extras/categories it discovers in sources.  This allows you to _render_ or _install_
+    from lockfiles of extras without needing to re-lock.
+
+    However this does make the assumption that *all* extras are installed, *and* installable in conjunction with each other.
+    If you want extras filtering to happen at the before solving use the flag `--filter-categories` or `--filter-extras`
+
+    sh```
+    conda-lock --extra incompatiblea --filter-categories -f pyproject.toml
+    ```
+
+    This will use the `--extras/--categories` flag as a filter.
+
+---
+
 ## --check-input-hash
 
 Under some situation you may want to run conda lock in some kind of automated way (eg as a precommit) and want to not

--- a/docs/src_pyproject.md
+++ b/docs/src_pyproject.md
@@ -115,6 +115,17 @@ conda-lock --extra mysql --extra pgsql -f pyproject.toml
 
 When generating lockfiles that make use of extras it is recommended to make use of `--filename-template` covered [here](#file-naming).
 
+!!! note ""
+
+    By default conda-lock will attempt to solve for *ALL* extras it discovers in sources.  This allows you to render explicit locks with subsets
+    of extras.
+
+    However this does make the assumption that your extras can all be installed in conjunction with each other.  If you want extras filtering
+    to happen at the solve stage use the flag `--filter-extras`
+
+    sh```
+    conda-lock --extra incompatiblea --filter-extras -f pyproject.toml
+    ```
 
 ## Extensions
 


### PR DESCRIPTION
This allows pre-solve filtering of categories/extras as was the behavior pre-1.0.  This is now an opt-in behavior.

Without using this flag a lock will solve for the whole dependency set instead of only the set of categories required.