### PR TITLE
Fix conda lock install on windows

### DIFF
--- a/conda_lock/common.py
+++ b/conda_lock/common.py
@@ -1,10 +1,22 @@
 import json
 import os
 import pathlib
+import tempfile
 import typing
 
+from contextlib import contextmanager
 from itertools import chain
-from typing import Any, Dict, Iterable, List, Mapping, Sequence, TypeVar, Union
+from typing import (
+    Any,
+    Dict,
+    Iterable,
+    Iterator,
+    List,
+    Mapping,
+    Sequence,
+    TypeVar,
+    Union,
+)
 
 
 if typing.TYPE_CHECKING:
@@ -41,6 +53,21 @@ def read_file(filepath: Union[str, pathlib.Path]) -> str:
 def write_file(obj: str, filepath: Union[str, pathlib.Path]) -> None:
     with open(filepath, mode="w") as fp:
         fp.write(obj)
+
+
+@contextmanager
+def temporary_file_with_contents(content: str) -> Iterator[pathlib.Path]:
+    """Generate a temporary file with the given content.  This file can be used by subprocesses
+
+    On Windows, NamedTemporaryFiles can't be opened a second time, so we have to close it first (and delete it manually later)
+    """
+    tf = tempfile.NamedTemporaryFile(delete=False)
+    try:
+        tf.close()
+        write_file(content, tf.name)
+        yield pathlib.Path(tf.name)
+    finally:
+        os.unlink(tf.name)
 
 
 def read_json(filepath: Union[str, pathlib.Path]) -> Dict:


### PR DESCRIPTION
Fixes #165 

Unify the way we make temporary files and pass them to conda.  This should fix PermissionError issues on windows