### PR TITLE
Workaround for windows platform - ansi symbols after output

### DIFF
--- a/conda_lock/conda_solver.py
+++ b/conda_lock/conda_solver.py
@@ -103,9 +103,9 @@ def _to_match_spec(
     return ms.conda_build_form()
 
 
-def strip_end_json_stdout(proc_stdout: str) -> str:
+def extract_json_object(proc_stdout: str) -> str:
     try:
-        return proc_stdout[: proc_stdout.rindex("}") + 1]
+        return proc_stdout[proc_stdout.index("{") : proc_stdout.rindex("}") + 1]
     except ValueError:
         return proc_stdout
 
@@ -229,7 +229,7 @@ def _reconstruct_fetch_actions(
             pkgs_dirs = [
                 pathlib.Path(d)
                 for d in json.loads(
-                    strip_end_json_stdout(
+                    extract_json_object(
                         subprocess.check_output(
                             [str(conda), "info", "--json"],
                             env=conda_env_override(platform),
@@ -366,7 +366,7 @@ def solve_specs_for_arch(
         raise
 
     try:
-        dryrun_install: DryRunInstall = json.loads(strip_end_json_stdout(proc.stdout))
+        dryrun_install: DryRunInstall = json.loads(extract_json_object(proc.stdout))
         return _reconstruct_fetch_actions(conda, platform, dryrun_install)
     except json.JSONDecodeError:
         raise

--- a/conda_lock/conda_solver.py
+++ b/conda_lock/conda_solver.py
@@ -103,6 +103,13 @@ def _to_match_spec(
     return ms.conda_build_form()
 
 
+def strip_end_json_stdout(proc_stdout: str) -> str:
+    try:
+        return proc_stdout[: proc_stdout.rindex("}") + 1]
+    except ValueError:
+        return proc_stdout
+
+
 def solve_conda(
     conda: PathLike,
     specs: Dict[str, Dependency],
@@ -222,8 +229,11 @@ def _reconstruct_fetch_actions(
             pkgs_dirs = [
                 pathlib.Path(d)
                 for d in json.loads(
-                    subprocess.check_output(
-                        [str(conda), "info", "--json"], env=conda_env_override(platform)
+                    strip_end_json_stdout(
+                        subprocess.check_output(
+                            [str(conda), "info", "--json"],
+                            env=conda_env_override(platform),
+                        ).decode()
                     )
                 )["pkgs_dirs"]
             ]
@@ -356,7 +366,7 @@ def solve_specs_for_arch(
         raise
 
     try:
-        dryrun_install: DryRunInstall = json.loads(proc.stdout)
+        dryrun_install: DryRunInstall = json.loads(strip_end_json_stdout(proc.stdout))
         return _reconstruct_fetch_actions(conda, platform, dryrun_install)
     except json.JSONDecodeError:
         raise

--- a/tests/test_conda_lock.py
+++ b/tests/test_conda_lock.py
@@ -39,7 +39,7 @@ from conda_lock.conda_lock import (
     parse_meta_yaml_file,
     run_lock,
 )
-from conda_lock.conda_solver import fake_conda_environment
+from conda_lock.conda_solver import fake_conda_environment, strip_end_json_stdout
 from conda_lock.errors import (
     ChannelAggregationError,
     MissingEnvVarError,
@@ -1192,3 +1192,8 @@ def test_private_lock(quetz_server, tmp_path, monkeypatch, capsys, conda_exe):
     monkeypatch.delenv("QUETZ_API_KEY")
     with pytest.raises(MissingEnvVarError):
         run_install()
+
+
+def test_strip_end_json_stdout():
+    assert strip_end_json_stdout('{"key1": true } ^[0m') == '{"key1": true }'
+    assert strip_end_json_stdout('{"key1": true }') == '{"key1": true }'

--- a/tests/test_conda_lock.py
+++ b/tests/test_conda_lock.py
@@ -39,7 +39,7 @@ from conda_lock.conda_lock import (
     parse_meta_yaml_file,
     run_lock,
 )
-from conda_lock.conda_solver import fake_conda_environment, strip_end_json_stdout
+from conda_lock.conda_solver import extract_json_object, fake_conda_environment
 from conda_lock.errors import (
     ChannelAggregationError,
     MissingEnvVarError,
@@ -1194,6 +1194,7 @@ def test_private_lock(quetz_server, tmp_path, monkeypatch, capsys, conda_exe):
         run_install()
 
 
-def test_strip_end_json_stdout():
-    assert strip_end_json_stdout('{"key1": true } ^[0m') == '{"key1": true }'
-    assert strip_end_json_stdout('{"key1": true }') == '{"key1": true }'
+def test_extract_json_object():
+    """It should remove all the characters after the last }"""
+    assert extract_json_object(' ^[0m {"key1": true } ^[0m') == '{"key1": true }'
+    assert extract_json_object('{"key1": true }') == '{"key1": true }'


### PR DESCRIPTION
When running conda-lock from a subprocess in a python script a few ANSI characters were appearing after calling conda/mamba/micromamba as a result it was raising an error when trying to convert the output of the process to a JSON object.
This commit has the intention to avoid this problem ignoring all the characters that might appear after the last closing bracket }