### PR TITLE
Set encoding when manipulating stdout

### DIFF
--- a/conda_lock/invoke_conda.py
+++ b/conda_lock/invoke_conda.py
@@ -110,6 +110,7 @@ def _invoke_conda(
         stderr=subprocess.PIPE,
         bufsize=1,
         universal_newlines=True,
+        encoding="utf-8",
     ) as p:
         stdout = []
         if p.stdout:


### PR DESCRIPTION
When manipulating stdout please set the encoding,  as the subprocess will use the default of the system it might get another encode than unicode that python uses as a default when decoding it. That is a particular problem when using mamba because it outputs some symbols that if the default of the system is not utf-8 or other similar encodings it will raise an exception.