### PR TITLE
sort packages prior to rendering

### DIFF
--- a/conda_lock/conda_lock.py
+++ b/conda_lock/conda_lock.py
@@ -555,6 +555,10 @@ def render_lockfile_for_platform(  # noqa: C901
 
     conda_deps = []
     pip_deps = []
+
+    # ensure consistent ordering of generated file
+    lockfile.toposort_inplace()
+
     for p in lockfile.package:
         if p.platform == platform and ((not p.optional) or (p.category in categories)):
             if p.manager == "pip":


### PR DESCRIPTION
ensures consistent package ordering, however lockfile object was produced

I'm guessing this is a redundant sort at least sometimes, but sorting immediately before generating output seems like the right place to ensure it always happens, unless topo sort is important earlier in the chain.

same issue as #170 in a different situation. fixes #183 
