### PR TITLE
Force resolving dependency via pip

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,6 +368,13 @@ python = "3.9"
 ampel-ztf = {version = "^0.8.0-alpha.2", source = "pypi"}
 ```
 
+A dependency will also be treated as a `pip` dependency if explicitly marked with `source = "pypi"` in the `[tool.conda-lock.dependencies]` section, e.g.:
+
+```toml
+[tool.conda-lock.dependencies]
+ampel-ztf = {source = "pypi"}
+```
+
 In both these cases, the dependencies of `pip`-installable packages will also be
 installed with `pip`, unless they were already requested by a `conda`
 dependency.

--- a/conda_lock/src_parser/pyproject_toml.py
+++ b/conda_lock/src_parser/pyproject_toml.py
@@ -162,23 +162,32 @@ def parse_poetry_pyproject_toml(
 def specification_with_dependencies(
     path: pathlib.Path, toml_contents: Mapping[str, Any], dependencies: List[Dependency]
 ) -> LockSpecification:
+    force_pypi = set()
     for depname, depattrs in get_in(
         ["tool", "conda-lock", "dependencies"], toml_contents, {}
     ).items():
         if isinstance(depattrs, str):
             conda_version = depattrs
+            dependencies.append(
+                VersionedDependency(
+                    name=depname,
+                    version=conda_version,
+                    manager="conda",
+                    optional=False,
+                    category="main",
+                    extras=[],
+                )
+            )
+        elif isinstance(depattrs, collections.abc.Mapping):
+            if depattrs.get("source", None) == "pypi":
+                force_pypi.add(depname)
         else:
             raise TypeError(f"Unsupported type for dependency: {depname}: {depattrs:r}")
-        dependencies.append(
-            VersionedDependency(
-                name=depname,
-                version=conda_version,
-                manager="conda",
-                optional=False,
-                category="main",
-                extras=[],
-            )
-        )
+
+    if force_pypi:
+        for dep in dependencies:
+            if dep.name in force_pypi:
+                dep.manager = "pip"
 
     return LockSpecification(
         dependencies=dependencies,

--- a/docs/src_pyproject.md
+++ b/docs/src_pyproject.md
@@ -170,5 +170,17 @@ the following sections to the `pyproject.toml`
 sqlite = ">=3.34"
 ```
 
+### Force pypi dependencies
+
+While it is with poetry, it is not possible to indicate a package's source in a `pyproject.toml` which follows PEP621.
+
+In that case, it is possible to force resolving a dependency as a pip dependency by indicating it in the same `pyproject.toml` section.
+
+This is useful in particular for packages that are not present on conda channels.
+
+```{.toml title="pyproject.toml"}
+[tool.conda-lock.dependencies]
+numpy = {source = "pypi"}
+```
 
 [mapping]: https://github.com/regro/cf-graph-countyfair/blob/master/mappings/pypi/grayskull_pypi_mapping.yaml

--- a/tests/test-flit/pyproject.toml
+++ b/tests/test-flit/pyproject.toml
@@ -25,3 +25,4 @@ channels = [
 [tool.conda-lock.dependencies]
 sqlite = "<3.34"
 certifi = ">=2019.11.28"
+toml = {source = "pypi"}

--- a/tests/test_conda_lock.py
+++ b/tests/test_conda_lock.py
@@ -442,6 +442,8 @@ def test_parse_flit(flit_pyproject_toml: Path):
     assert specs["pytest"].optional is True
     assert specs["pytest"].category == "dev"
 
+    assert specs["toml"].manager == "pip"
+
     assert res.channels == [Channel.from_string("defaults")]
 
 


### PR DESCRIPTION
Use the `[tool.conda-lock.dependencies]` section in the `pyproject.toml` file to force resolving a package via pip, fixing (part of) https://github.com/conda-incubator/conda-lock/issues/115.

This is useful in particular for packages that are not present on conda channels.

Note that

- I have used the `{source = 'pypi'}` syntax to flag a package which should be installed via pip to match how conda-locks interprets poetry sections. In case of poetry, `source` designate the pypi repository where the package should be downloaded. i.e. it could be a different (e.g. private) repository, in which case conda-lock should most likely also flag it as a pip installable-package. This is a question broader than this PR though, so I assume this should be OK here, and dealt with more broadly.
- If a package marked with `{source = 'pypi'}` in the `[tool.conda-lock.dependencies]` is not present in the packages dependencies (specified outside of `[tool.conda-lock.dependencies]`), it will not be added as a dependency. This makes sense to me as something downloaded via pip should be a python dependency. Currently it will be ignored silently - maybe a warning would be handy here?