### PR TITLE
Use absolute path to sources

### DIFF
--- a/conda_lock/conda_lock.py
+++ b/conda_lock/conda_lock.py
@@ -740,9 +740,7 @@ def create_lockfile_from_spec(
             content_hash=spec.content_hash(),
             channels=[c for c in spec.channels],
             platforms=spec.platforms,
-            sources=[
-                relative_path(lockfile_path.parent, source) for source in spec.sources
-            ],
+            sources=[str(source.resolve()) for source in spec.sources],
         ),
     )
 


### PR DESCRIPTION
Creates absolute paths instead of relative paths. Latter one is a problem, if the source path and target path do not share a common drive. Then the path cannot be converted to relative.

Note: I am not aware of possible side effects, as I haven't checked for such. However, tests are green.

Fix #175