### PR TITLE
Sort packages by name for lock files of kind "env".

### DIFF
--- a/conda_lock/conda_lock.py
+++ b/conda_lock/conda_lock.py
@@ -602,7 +602,7 @@ def render_lockfile_for_platform(  # noqa: C901
                 "dependencies:",
                 *(
                     f"  - {format_conda_requirement(dep, platform, direct=False)}"
-                    for dep in conda_deps
+                    for dep in sorted(conda_deps, key=lambda dep: dep.name)
                 ),
             ]
         )
@@ -611,7 +611,7 @@ def render_lockfile_for_platform(  # noqa: C901
                 "  - pip:",
                 *(
                     f"    - {format_pip_requirement(dep, platform, direct=False)}"
-                    for dep in pip_deps
+                    for dep in sorted(pip_deps, key=lambda dep: dep.name)
                 ),
             ]
             if pip_deps


### PR DESCRIPTION
Since these lock files will be resolved during installation, sorting topologically does not offer any benefit, and sorting alphabetically makes it much easier to find specific packages.

Since my original PR that added support for env files, we've been using and loving `conda-lock`, but one thing that's a bit annoying is the order of the packages in the generated environment file. For explicit locks this makes a lot of sense (since it guarantees safety during installation), but since the solver runs every time for env files anyway, it is much more convenient for us if the packages are sorted alphabetically. While we can always manually do this outside of `conda-lock`, it would be great if the `conda-lock` did this for us.

I'm open to suggestions for improvements and also this PR being rejected if consistency with the ordering of other lock files is more important to you than to me :).