### PR TITLE
Fix deprecated keys in setup.cfg

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=41.2", "setuptools_scm", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,7 @@ url = https://github.com/conda-incubator/conda-lock
 long_description_content_type = text/markdown
 long_description = file: README.md
 license = MIT
-license_file = LICENSE
+license_files = LICENSE
 classifiers =
     Development Status :: 5 - Production/Stable
     Intended Audience :: Science/Research
@@ -45,9 +45,6 @@ install_requires =
     typing-extensions
 python_requires = >=3.6
 packages = find:
-setup_requires =
-    setuptools >= 41.2
-    setuptools_scm
 
 [options.extras_require]
 pip_support = poetry ==1.1.*

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,7 @@
 from setuptools import setup
 
 
-setup(use_scm_version=True)
+setup(
+    name="conda_lock",
+    use_scm_version=True,
+)


### PR DESCRIPTION
~~Don't merge this yet. I'm trying to make it possible to install from the GitHub main branch too but I need to make a few extra adjustments.~~

Actually this is not needed, one can just install from "git" instead of a zipped git URL, from the error message:

```
For example, if you're using pip, instead of https://github.com/user/proj/archive/master.zip use git+https://github.com/user/proj.git#egg=proj
```

This is ready for review now.