### PR TITLE
Adding private pip repo support for legacy pypi repos.

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,13 @@ The default category is `main`.
 [environment.yml][envyaml], using [Poetry's][poetry] dependency solver, if
 installed with the `pip_support` extra.
 
+### private pip repositories
+Right now `conda-lock` only supports [legacy](https://warehouse.pypa.io/api-reference/legacy.html) pypi repos with basic auth. Most self-hosted repositories like Nexus, Artifactory etc. use this. To use this feature, add your private repo into Poetry's config _including_ the basic auth in the url:
+
+```bash
+poetry config repositories.foo https://username:password@foo.repo/simple/
+```
+
 ### --dev-dependencies/--no-dev-dependencies
 
 By default conda-lock will include dev dependencies in the specification of the lock (if the files that the lock

--- a/conda_lock/pypi_solver.py
+++ b/conda_lock/pypi_solver.py
@@ -206,7 +206,7 @@ def solve_pypi(
         )
         for source in config.get("repositories", {}).items()
     ]
-    
+
     pypi = PyPiRepository()
     pool = Pool(repositories=[*repos, pypi])
 

--- a/conda_lock/pypi_solver.py
+++ b/conda_lock/pypi_solver.py
@@ -17,6 +17,7 @@ from poetry.repositories.pool import Pool
 from poetry.repositories.pypi_repository import PyPiRepository
 from poetry.repositories.repository import Repository
 from poetry.utils.env import Env
+from poetry.factory import Factory
 
 from conda_lock import src_parser
 from conda_lock.lookup import conda_name_to_pypi_name
@@ -197,8 +198,13 @@ def solve_pypi(
     for dep in dependencies:
         dummy_package.add_dependency(dep)
 
+    factory = Factory()
+    config =factory.create_config()
+    repos = [factory.create_legacy_repository({'name':source[0], 'url':source[1]['url']}, config) 
+                for source in config.get("repositories", {}).items()]
+
     pypi = PyPiRepository()
-    pool = Pool(repositories=[pypi])
+    pool = Pool(repositories=[*repos, pypi])
 
     installed = Repository()
     locked = Repository()

--- a/conda_lock/pypi_solver.py
+++ b/conda_lock/pypi_solver.py
@@ -10,6 +10,7 @@ from clikit.api.io.flags import VERY_VERBOSE
 from clikit.io import ConsoleIO, NullIO
 from packaging.tags import compatible_tags, cpython_tags
 from poetry.core.packages import Dependency, Package, ProjectPackage, URLDependency
+from poetry.factory import Factory
 from poetry.installation.chooser import Chooser
 from poetry.installation.operations.uninstall import Uninstall
 from poetry.puzzle import Solver
@@ -17,7 +18,6 @@ from poetry.repositories.pool import Pool
 from poetry.repositories.pypi_repository import PyPiRepository
 from poetry.repositories.repository import Repository
 from poetry.utils.env import Env
-from poetry.factory import Factory
 
 from conda_lock import src_parser
 from conda_lock.lookup import conda_name_to_pypi_name
@@ -199,10 +199,14 @@ def solve_pypi(
         dummy_package.add_dependency(dep)
 
     factory = Factory()
-    config =factory.create_config()
-    repos = [factory.create_legacy_repository({'name':source[0], 'url':source[1]['url']}, config) 
-                for source in config.get("repositories", {}).items()]
-
+    config = factory.create_config()
+    repos = [
+        factory.create_legacy_repository(
+            {"name": source[0], "url": source[1]["url"]}, config
+        )
+        for source in config.get("repositories", {}).items()
+    ]
+    
     pypi = PyPiRepository()
     pool = Pool(repositories=[*repos, pypi])
 


### PR DESCRIPTION
This PR adds private repo support for legacy pypi repositories allowing pip dependencies to be installed from private repos. This should enable most self-hosted private repos to be used (like Nexus and Artifactory). Please see the README for more details.