### PR TITLE
Documentation fix

### DIFF
--- a/docs/output.md
+++ b/docs/output.md
@@ -10,7 +10,7 @@ This is defined by a [pydantic](https://pydantic-docs.helpmanual.io/usage/models
 In order to explicitly use this format
 
 ```shell
-conda-lock --kind lockfile
+conda-lock --kind lock
 ```
 
 To install from one of these lockfiles
@@ -19,9 +19,11 @@ To install from one of these lockfiles
 conda-lock install conda-lock.yml
 ```
 
+For proper parsing the unified lockfile must have the proper `.conda-lock.yml` extension (e.g foo.conda-lock.yml)
+
 ### Render
 
-The unified lockfile can be rendered into the various other lockfile formats
+The unified lockfile can be rendered into the various other lockfile formats.
 
 Generate both formats using
 


### PR DESCRIPTION
Some small chanegs to make the documentation more accurate and usable:
Fix --kind argument ('lockfile' does not exist but 'lock' is given in the CLI docs and the codes seems to use `List[Union[Literal["lock"], Literal["env"], Literal["explicit"]]]`)
Add mention of the complete file extension requirement for install as mentionned in #154 

Also if there's an easy way to do this it could be nice the freeze the docs to the current release (e.g for now the docs says the --platform argument can be used with render but the related commit c0397b6476427c96c2f1cd70ac52d2e1254acf0a introducing the CLI argument has been introduced after the current 1.0.5 release) 

Thanks for this great tool!