### PR TITLE
Fix handling of default sources 

### DIFF
--- a/conda_lock/conda_lock.py
+++ b/conda_lock/conda_lock.py
@@ -939,9 +939,18 @@ def run_lock(
                     file=sys.stderr,
                 )
         else:
-            long_ext_file = pathlib.Path("environment.yaml")
-            if long_ext_file.exists() and not environment_files[0].exists():
-                environment_files = [long_ext_file]
+            # bail out if we do not encounter any default .y(a)ml files
+            candidates = [
+                p if p.exists() else p.with_suffix(".yaml") for p in DEFAULT_FILES
+            ]
+            environment_files = [p for p in candidates if p.exists()]
+            if len(environment_files) == 0:
+                print(
+                    f"No files exist matching the defaults"
+                    f" ({[str(p.with_suffix('.y(a)ml')) for p in DEFAULT_FILES]}).",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
 
     _conda_exe = determine_conda_executable(
         conda_exe, mamba=mamba, micromamba=micromamba
@@ -1130,17 +1139,6 @@ def lock(
     # Set Pypi <--> Conda lookup file location
     if pypi_to_conda_lookup_file:
         set_lookup_location(pypi_to_conda_lookup_file)
-
-    # bail out if we do not encounter the default file if no files were passed
-    if ctx.get_parameter_source("files") == click.core.ParameterSource.DEFAULT:
-        candidates = list(files)
-        candidates += [f.with_name(f.name.replace(".yml", ".yaml")) for f in candidates]
-        for f in candidates:
-            if f.exists():
-                break
-        else:
-            print(ctx.get_help())
-            sys.exit(1)
 
     if pdb:
         sys.excepthook = _handle_exception_post_mortem

--- a/conda_lock/conda_lock.py
+++ b/conda_lock/conda_lock.py
@@ -932,15 +932,15 @@ def run_lock(
             if all(p.exists() for p in locked_environment_files):
                 environment_files = locked_environment_files
             else:
-                environment_files = DEFAULT_FILES
                 missing = [p for p in locked_environment_files if not p.exists()]
                 print(
                     f"{lockfile_path} was created from {[str(p) for p in locked_environment_files]},"
                     f" but some files ({[str(p) for p in missing]}) do not exist. Falling back to"
-                    f" {[str(p) for p in environment_files]}.",
+                    f" {[str(p) for p in DEFAULT_FILES]}.",
                     file=sys.stderr,
                 )
-        else:
+        # always re-check in case no files from the lockfile were assigned
+        if len(environment_files) == 0:
             # bail out if we do not encounter any default .y(a)ml files
             candidates = [
                 p if p.exists() else p.with_suffix(".yaml") for p in DEFAULT_FILES

--- a/conda_lock/conda_lock.py
+++ b/conda_lock/conda_lock.py
@@ -917,7 +917,8 @@ def run_lock(
     update: Optional[List[str]] = None,
     filter_categories: bool = False,
 ) -> None:
-    if environment_files == DEFAULT_FILES:
+    # no environment files specified => from lockfile or defaults
+    if len(environment_files) == 0:
         if lockfile_path.exists():
             lock_content = parse_conda_lock_file(lockfile_path)
             # reconstruct native paths
@@ -931,6 +932,7 @@ def run_lock(
             if all(p.exists() for p in locked_environment_files):
                 environment_files = locked_environment_files
             else:
+                environment_files = DEFAULT_FILES
                 missing = [p for p in locked_environment_files if not p.exists()]
                 print(
                     f"{lockfile_path} was created from {[str(p) for p in locked_environment_files]},"
@@ -1139,6 +1141,11 @@ def lock(
     # Set Pypi <--> Conda lookup file location
     if pypi_to_conda_lookup_file:
         set_lookup_location(pypi_to_conda_lookup_file)
+
+    # we need to distinguish between unspecified files and specified but same as default
+    # (while keeping the CLI default to have it in the --help)
+    if ctx.get_parameter_source("files") == click.core.ParameterSource.DEFAULT:
+        files = []
 
     if pdb:
         sys.excepthook = _handle_exception_post_mortem

--- a/tests/test_conda_lock.py
+++ b/tests/test_conda_lock.py
@@ -24,7 +24,6 @@ import yaml
 from flaky import flaky
 
 from conda_lock.conda_lock import (
-    DEFAULT_FILES,
     DEFAULT_LOCKFILE_NAME,
     _add_auth_to_line,
     _add_auth_to_lockfile,
@@ -532,7 +531,7 @@ def test_run_lock_with_locked_environment_files(
     run_lock([pre_environment], conda_exe="mamba")
     make_lock_files = MagicMock()
     monkeypatch.setattr("conda_lock.conda_lock.make_lock_files", make_lock_files)
-    run_lock(DEFAULT_FILES, conda_exe=conda_exe, update=["pydantic"])
+    run_lock([], conda_exe=conda_exe, update=["pydantic"])
     if sys.version_info < (3, 8):
         # backwards compat
         src_files = make_lock_files.call_args_list[0][1]["src_files"]


### PR DESCRIPTION
Resolves #231, also
* making sure to handle separately the case of unspecified `--file` arguments from the case when `--file environment.y(a)ml` is explicitly used
* reviewing the checks for unspecified sources, also covering the usage of the defaults as fall-back when the lockfile exists