### PR TITLE
Add package_type = "virtual_system" to FakePackage

### DIFF
--- a/conda_lock/virtual_package.py
+++ b/conda_lock/virtual_package.py
@@ -33,6 +33,7 @@ class FakePackage(BaseModel):
     noarch: str = ""
     depends: Tuple[str, ...] = Field(default_factory=tuple)
     timestamp: int = DEFAULT_TIME
+    package_type: Optional[str] = "virtual_system"
 
     def to_repodata_entry(self) -> Tuple[str, Dict[str, Any]]:
         out = self.dict()

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,6 @@ ensureconda>=1.3.0
 click>=8.0
 click-default-group
 pydantic
-poetry
+poetry<1.2
 ruamel.yaml
 typing-extensions

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,7 +46,7 @@ install_requires =
     click-default-group
     pydantic >=1.8.1
     ruamel.yaml
-    poetry
+    poetry <1.2
     typing-extensions
 python_requires = >=3.6
 packages = find:

--- a/tests/test_conda_lock.py
+++ b/tests/test_conda_lock.py
@@ -1171,7 +1171,7 @@ def test_virtual_package_input_hash_stability():
         sources=[],
         virtual_package_repo=vpr,
     )
-    expected = "d8d0e556f97aed2eaa05fe9728b5a1c91c1b532d3eed409474e8a9b85b633a26"
+    expected = "8ee5fc79fca4cb7732d2e88443209e0a3a354da9899cb8899d94f9b1dcccf975"
     assert spec.content_hash() == {"linux-64": expected}
 
 
@@ -1181,12 +1181,12 @@ def test_default_virtual_package_input_hash_stability():
     vpr = default_virtual_package_repodata()
 
     expected = {
-        "linux-64": "93c22a62ca75ed0fd7649a6c9fbac611fd42a694465841b141c91aa2d4edf1b3",
-        "linux-aarch64": "e1115c4d229438be0bd3e79c3734afb1f2fb8db42cf0c20c0e2ede5405e97e25",
-        "linux-ppc64le": "d980051789ba7e6374c0833bf615b060bc0c5dfa63907eb4f11ac85f4dbb80da",
-        "osx-64": "8e2e62ea8061892d10606e9a10f05f4c7358c798e5a2d390b1206568bf9338a2",
-        "osx-arm64": "00eb1bef60572765717bba1fd86da4527f3b69bd40eb51cd0b60cdc89c27f5a6",
-        "win-64": "d97edec84c3f450ac23bd2fbac57f77c0b0bffd5313114c1fa8c28c4df8ead6e",
+        "linux-64": "dbd71bccc4b3be81038e44b1f14891ccec40a6d70a43cfe02295fc77a2ea9eb5",
+        "linux-aarch64": "023611fb84c00fb5aaeddde1e0ac62e6ae007aecf6f69ccb5dbfc3cd6d945436",
+        "linux-ppc64le": "8533a7bd0e950f7b085eeef7686d2c4895e84b8ffdbfba6d62863072ac41090c",
+        "osx-64": "b7eebe4be0654740f67e3023f2ede298f390119ef225f50ad7e7288ea22d5c93",
+        "osx-arm64": "cc82018d1b1809b9aebacacc5ed05ee6a4318b3eba039607d2a6957571f8bf2b",
+        "win-64": "44239e9f0175404e62e4a80bb8f4be72e38c536280d6d5e484e52fa04b45c9f6",
     }
 
     spec = LockSpecification(


### PR DESCRIPTION
I hope that this solves #202.

The tests are taking forever when I run locally.

They finally finished and apart from one concerning error, it looks like I just have to update some of the expected hash values.

<details>

<summary>The concerning error</summary>

```
./tests/test_conda_lock.py::test_run_with_channel_inversion Failed: [undefined]conda_lock.vendor.poetry.utils._compat.CalledProcessError: Command '['/home/mares/micromamba/condabin/mamba', 'create', '--prefix', '/tmp/tmpuglh4xow/prefix', '--dry-run', '--json', '--override-channels', '--channel', 'rapidsai', '--channel', 'nvidia', '--channel', 'conda-forge', '--channel', 'file:///tmp/tmpe6vs4lv8', 'cudf', 'conda-forge::cuda-python']' returned non-zero exit status 1.
monkeypatch = <_pytest.monkeypatch.MonkeyPatch object at 0x7f4f823d6e30>
channel_inversion = PosixPath('/tmp/pytest-of-mares/pytest-10/test_run_with_channel_inversio0/environment.yaml')
mamba_exe = PosixPath('/home/mares/micromamba/condabin/mamba')

    def test_run_with_channel_inversion(
        monkeypatch: "pytest.MonkeyPatch", channel_inversion: Path, mamba_exe: str
    ):
        """Given that the cuda_python package is available from a few channels
        and three of those channels listed
        and with conda-forge listed as the lowest priority channel
        and with the cuda_python dependency listed as "conda-forge::cuda_python",
        ensure that the lock file parse picks up conda-forge as the channel and not one of the higher priority channels
        """
        monkeypatch.chdir(channel_inversion.parent)
>       run_lock([channel_inversion], conda_exe=mamba_exe, platforms=["linux-64"])

/home/mares/repos/conda-lock/tests/test_conda_lock.py:692: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/home/mares/repos/conda-lock/conda_lock/conda_lock.py:950: in run_lock
    make_lock_files(
/home/mares/repos/conda-lock/conda_lock/conda_lock.py:389: in make_lock_files
    lock_content = lock_content | create_lockfile_from_spec(
/home/mares/repos/conda-lock/conda_lock/conda_lock.py:738: in create_lockfile_from_spec
    deps = _solve_for_arch(
/home/mares/repos/conda-lock/conda_lock/conda_lock.py:689: in _solve_for_arch
    conda_deps = solve_conda(
/home/mares/repos/conda-lock/conda_lock/conda_solver.py:169: in solve_conda
    dry_run_install = solve_specs_for_arch(
/home/mares/repos/conda-lock/conda_lock/conda_solver.py:356: in solve_specs_for_arch
    proc.check_returncode()
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = CompletedProcess(args=['/home/mares/micromamba/condabin/mamba', 'create', '--prefix', '/tmp/tmpuglh4xow/prefix', '--dr...kage cuda-python-11.7.1-py39h1eff087_0 is excluded by strict repo priority\n\n{\n    "success": false\n}\n', stderr='')

    def check_returncode(self):
        """Raise CalledProcessError if the exit code is non-zero."""
        if self.returncode:
>           raise CalledProcessError(
                self.returncode, self.args, self.stdout, self.stderr
            )
E           conda_lock.vendor.poetry.utils._compat.CalledProcessError: Command '['/home/mares/micromamba/condabin/mamba', 'create', '--prefix', '/tmp/tmpuglh4xow/prefix', '--dry-run', '--json', '--override-channels', '--channel', 'rapidsai', '--channel', 'nvidia', '--channel', 'conda-forge', '--channel', 'file:///tmp/tmpe6vs4lv8', 'cudf', 'conda-forge::cuda-python']' returned non-zero exit status 1.

/home/mares/repos/conda-lock/conda_lock/vendor/poetry/utils/_compat.py:168: CalledProcessError
```

</details>

Let's see how it looks on the CI...