### PR TITLE
Minor refactoring

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 For the most up-to-date instructions see the github actions [test.yml workflow](./github/workflows.test.yml)
 
 1. Ensure conda and mamba are installed. Install [mambaforge](https://github.com/conda-forge/miniforge#mambaforge) if you're otherwise not sure which one to pick.
-2. `mamba create -n conda-lock-dev pip pytest-cov pytest-xdist pip`
+2. `mamba create -n conda-lock-dev pip pytest-cov pytest-xdist`
 3. `conda activate conda-lock-dev`
 4. `python -m pip install -r requirements-dev.txt`
 5. `pip install -e . --no-deps --force-reinstall`

--- a/conda_lock/pypi_solver.py
+++ b/conda_lock/pypi_solver.py
@@ -214,18 +214,19 @@ def solve_pypi(
     locked = Repository()
 
     python_packages = dict()
-    for dep in conda_locked.values():
-        if dep.name.startswith("__"):
+    locked_dep: src_parser.LockedDependency
+    for locked_dep in conda_locked.values():
+        if locked_dep.name.startswith("__"):
             continue
         try:
-            pypi_name = conda_name_to_pypi_name(dep.name).lower()
+            pypi_name = conda_name_to_pypi_name(locked_dep.name).lower()
         except KeyError:
             continue
         # Prefer the Python package when its name collides with the Conda package
         # for the underlying library, e.g. python-xxhash (pypi: xxhash) over xxhash
         # (pypi: no equivalent)
-        if pypi_name not in python_packages or pypi_name != dep.name:
-            python_packages[pypi_name] = dep.version
+        if pypi_name not in python_packages or pypi_name != locked_dep.name:
+            python_packages[pypi_name] = locked_dep.version
     # treat conda packages as both locked and installed
     for name, version in python_packages.items():
         for repo in (locked, installed):
@@ -299,13 +300,13 @@ def solve_pypi(
         # prefer conda packages so add them afterwards
     }
 
-    for conda_name, dep in conda_locked.items():
+    for conda_name, locked_dep in conda_locked.items():
         try:
             pypi_name = conda_name_to_pypi_name(conda_name).lower()
         except KeyError:
             # no conda-name found, assuming conda packages do NOT intersect with the pip package
             continue
-        planned[pypi_name] = dep
+        planned[pypi_name] = locked_dep
 
     src_parser._apply_categories(requested=pip_specs, planned=planned)
 

--- a/conda_lock/pypi_solver.py
+++ b/conda_lock/pypi_solver.py
@@ -276,7 +276,10 @@ def solve_pypi(
             else:
                 link = chooser.choose_for(op.package)
                 url = link.url_without_fragment
-                hash = src_parser.HashModel(**{link.hash_name: link.hash})
+                hashes: Dict[str, str] = {}
+                if link.hash_name is not None and link.hash is not None:
+                    hashes[link.hash_name] = link.hash
+                hash = src_parser.HashModel.parse_obj(hashes)
 
             requirements.append(
                 src_parser.LockedDependency(


### PR DESCRIPTION
Here are a few really minor refactoring things I did in preparation for vendoring Poetry in #240, which should be very straightforward to review.

1. Fix typo in docs: `pip` was listed twice as a dependency in `CONTRIBUTING.md`.
2. The variable `dep` was being used as both `Dependency` and `LockedDependency` types, so to make type checkers happier, I renamed the `LockedDependency` instances of `dep` to `locked_dep`.
3. When initializing the `HashModel` object, it is possible (from the typing perspective if not in practice) that `link.hash_name` and `link.hash` are `None`. Thus `HashModel(**{link.hash_name: link.hash})` would expand to `HashModel(None=None)`, which would result in `TypeError: keywords must be strings`. I rewrote this bit of code to be a bit lengthier, but more explicit and robust.