### PR TITLE
Remove deprecated isort option

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,6 @@ include_trailing_comma = true
 lines_after_imports = 2
 lines_between_types = 1
 multi_line_output = 3
-not_skip = "__init__.py"
 use_parentheses = true
 known_first_party = "attr"
 


### PR DESCRIPTION
This option is no longer necessary as of v5. We are on v5.

<https://pycqa.github.io/isort/docs/upgrade_guides/5.0.0.html#-dont-skip-or-ns>