### PR TITLE
Add .micromamba/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ tests/**/*.bak
 site/
 filelock
 .coverage
+.micromamba/


### PR DESCRIPTION
It seems that pytest creates a `.micromamba/` directory in the repository root, so we should add it to `.gitignore`.