### PR TITLE
use stdlib or tomli for toml parsing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,9 +47,6 @@ jobs:
       matrix:
         os: [ ubuntu-latest, macos-latest ]
         python-version: [ '3.7', '3.8' ]
-        include:
-          - os: ubuntu-latest
-            python-version: '3.11-dev'
     defaults:
       run:
         shell: bash -l {0}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,10 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, macos-latest ]
-        python-version: [ 3.7, 3.8 ]
+        python-version: [ '3.7', '3.8' ]
+        include:
+          - os: ubuntu-latest
+            python-version: '3.11-dev'
     defaults:
       run:
         shell: bash -l {0}

--- a/conda_lock/src_parser/pyproject_toml.py
+++ b/conda_lock/src_parser/pyproject_toml.py
@@ -199,7 +199,8 @@ def to_match_spec(conda_dep_name: str, conda_version: Optional[str]) -> str:
 def parse_pyproject_toml(
     pyproject_toml: pathlib.Path,
 ) -> LockSpecification:
-    contents = toml_load(pyproject_toml)
+    with pyproject_toml.open("rb") as fp:
+        contents = toml_load(fp)
     build_system = get_in(["build-system", "build-backend"], contents)
     pep_621_probe = get_in(["project", "dependencies"], contents)
     pdm_probe = get_in(["tool", "pdm"], contents)

--- a/conda_lock/src_parser/pyproject_toml.py
+++ b/conda_lock/src_parser/pyproject_toml.py
@@ -6,6 +6,7 @@ from functools import partial
 from typing import AbstractSet, Any, List, Mapping, Optional, Sequence, Union
 from urllib.parse import urldefrag
 
+
 try:
     from tomllib import load as toml_load
 except ImportError:

--- a/conda_lock/src_parser/pyproject_toml.py
+++ b/conda_lock/src_parser/pyproject_toml.py
@@ -6,7 +6,10 @@ from functools import partial
 from typing import AbstractSet, Any, List, Mapping, Optional, Sequence, Union
 from urllib.parse import urldefrag
 
-import toml
+try:
+    from tomllib import load as toml_load
+except ImportError:
+    from tomli import load as toml_load
 
 from typing_extensions import Literal
 
@@ -195,7 +198,7 @@ def to_match_spec(conda_dep_name: str, conda_version: Optional[str]) -> str:
 def parse_pyproject_toml(
     pyproject_toml: pathlib.Path,
 ) -> LockSpecification:
-    contents = toml.load(pyproject_toml)
+    contents = toml_load(pyproject_toml)
     build_system = get_in(["build-system", "build-backend"], contents)
     pep_621_probe = get_in(["project", "dependencies"], contents)
     pdm_probe = get_in(["tool", "pdm"], contents)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -17,7 +17,7 @@ pytest-cov
 pytest-flake8
 pytest-xdist
 pytest-timeout
-toml
+tomli; python_version<"3.11"
 twine
 wheel
 mkdocs

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,5 @@ pydantic >=1.8.1
 pyyaml >= 5.1
 requests >=2
 ruamel.yaml
-toml
+tomli; python_version<"3.11"
 typing-extensions


### PR DESCRIPTION
Per https://github.com/conda-incubator/conda-lock/pull/249/files#r985297741, this changes the dependency on `toml` to `tomli`, but prefers stdlib if available.