### PR TITLE
Fix aggregating lock specs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 
 ## Developing
 
-For the most up-to-date instructions see the github actions [test.yml workflow](./github/workflows.test.yml)
+For the most up-to-date instructions see the github actions [test.yml workflow](./.github/workflows/test.yml)
 
 1. Ensure conda and mamba are installed. Install [mambaforge](https://github.com/conda-forge/miniforge#mambaforge) if you're otherwise not sure which one to pick.
 2. `mamba create -n conda-lock-dev pip pytest-cov pytest-xdist`

--- a/conda_lock/src_parser/__init__.py
+++ b/conda_lock/src_parser/__init__.py
@@ -339,8 +339,10 @@ def aggregate_lock_specs(
     ):
         key = (dep.manager, dep.name)
         if key in unique_deps:
-            unique_deps[key].selectors |= dep.selectors
-        # overrides always win.
+            # Override existing, but merge selectors
+            previous_selectors = unique_deps[key].selectors
+            previous_selectors |= dep.selectors
+            dep.selectors = previous_selectors
         unique_deps[key] = dep
 
     dependencies = list(unique_deps.values())


### PR DESCRIPTION
This should fix #257 where dependencies would only ever be locked for one platform for a recipe (`meta.yaml`), even when using multiple `-p` flags. 

Seems like this was due to incorrectly aggregating selectors when overriding an existing spec.

Fixes #257 