### PR TITLE
Stress that .lock extension is necessary

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ conda-lock --lockfile superspecial.conda-lock.yml
 ```
 
 The extension `.conda-lock.yml` will be added if not present. Rendered
-environment files (env or explicit) will be named as as
-`"conda-{platform}.lock"`.
+environment files (env or explicit) must end with `.lock` and will be named as
+`"conda-{platform}.lock"` by default.
 
 If you want to override that call conda-lock as follows.
 ```bash


### PR DESCRIPTION
It took me a while to realize that conda/mamba refuses to deal with conda-lock files if they have a yaml ending (throwing a very ugly decoding error).

This PR tries to make this more clear in the readme (though it is more of an issue with conda/mamba, I guess).

(Also see https://github.com/mamba-org/provision-with-micromamba/issues/106)