### PR TITLE
Suggest how to solve PlatformValidationError

### DIFF
--- a/conda_lock/conda_lock.py
+++ b/conda_lock/conda_lock.py
@@ -873,7 +873,13 @@ def _render_lockfile_for_install(
     platform = platform_subdir()
     if platform not in lock_content.metadata.platforms:
         raise PlatformValidationError(
-            f"Dependencies are not locked for the current platform ({platform})"
+            f"The lockfile {filename} does not contain a solution for the current "
+            f"platform {platform}. The lockfile only contains solutions for the "
+            f"following platforms: {', '.join(lock_content.metadata.platforms)}. In "
+            f"order to support {platform}, you must regenerate the lockfile. Either "
+            f"add a 'platforms:' section to your environment.yml containing "
+            f"'- {platform}', or add the '--platform={platform}' argument to the "
+            f"conda-lock command."
         )
 
     # TODO: Move to LockFile

--- a/conda_lock/conda_lock.py
+++ b/conda_lock/conda_lock.py
@@ -878,8 +878,9 @@ def _render_lockfile_for_install(
             f"following platforms: {', '.join(lock_content.metadata.platforms)}. In "
             f"order to support {platform}, you must regenerate the lockfile. Either "
             f"add a 'platforms:' section to your environment.yml containing "
-            f"'- {platform}', or add the '--platform={platform}' argument to the "
-            f"conda-lock command."
+            f"'- {platform}', or by adding the arguments '--platform="
+            f"{' --platform='.join([platform] + lock_content.metadata.platforms)}' "
+            f"to the conda-lock command."
         )
 
     # TODO: Move to LockFile

--- a/conda_lock/conda_lock.py
+++ b/conda_lock/conda_lock.py
@@ -872,15 +872,22 @@ def _render_lockfile_for_install(
 
     platform = platform_subdir()
     if platform not in lock_content.metadata.platforms:
+        suggested_platforms_section = "platforms:\n- "
+        suggested_platforms_section += "\n- ".join(
+            [platform] + lock_content.metadata.platforms
+        )
+        suggested_platform_args = "--platform=" + " --platform=".join(
+            [platform] + lock_content.metadata.platforms
+        )
         raise PlatformValidationError(
             f"The lockfile {filename} does not contain a solution for the current "
             f"platform {platform}. The lockfile only contains solutions for the "
             f"following platforms: {', '.join(lock_content.metadata.platforms)}. In "
-            f"order to support {platform}, you must regenerate the lockfile. Either "
-            f"add a 'platforms:' section to your environment.yml containing "
-            f"'- {platform}', or by adding the arguments '--platform="
-            f"{' --platform='.join([platform] + lock_content.metadata.platforms)}' "
-            f"to the conda-lock command."
+            f"order to add support for {platform}, you must regenerate the lockfile. "
+            f"Either add the following section to your environment.yml:\n\n"
+            f"{suggested_platforms_section}\n\n"
+            f"or add the following arguments to the conda-lock command:\n\n"
+            f"{suggested_platform_args}\n\n"
         )
 
     # TODO: Move to LockFile


### PR DESCRIPTION
Closes #281

Example error message:
```
conda_lock.errors.PlatformValidationError: The lockfile conda-lock.yml does not contain
a solution for the current platform linux-64. The lockfile only contains solutions for
the following platforms: osx-64. In order to add support for linux-64, you must
regenerate the lockfile. Either add the following section to your environment.yml:

platforms:
- linux-64
- osx-64

or add the following arguments to your conda-lock command:

--platform=linux-64 --platform=osx-64
```
