### PR TITLE
make gitpython dependency optional

### DIFF
--- a/conda_lock/conda_lock.py
+++ b/conda_lock/conda_lock.py
@@ -840,11 +840,6 @@ def create_lockfile_from_spec(
     else:
         git_metadata = None
 
-    git_metadata = GitMeta.create(
-        metadata_choices=metadata_choices,
-        src_files=spec.sources,
-    )
-
     if metadata_choices & {MetadataOption.InputSha, MetadataOption.InputMd5}:
         inputs_metadata: Optional[Dict[str, InputMeta]] = {
             relative_path: InputMeta.create(

--- a/conda_lock/src_parser/__init__.py
+++ b/conda_lock/src_parser/__init__.py
@@ -169,7 +169,10 @@ class GitMeta(StrictModel):
         metadata_choices: AbstractSet[MetadataOption],
         src_files: List[pathlib.Path],
     ) -> "GitMeta | None":
-        import git
+        try:
+            import git
+        except ImportError:
+            return None
 
         git_sha: "str | None" = None
         git_user_name: "str | None" = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dynamic = ["dependencies", "version"]
 license-files = { paths = ["LICENSE"] }
 
 [project.optional-dependencies]
+git_support = ["gitpython"]
 pip_support = ["poetry ==1.1.*"]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,6 @@ dynamic = ["dependencies", "version"]
 license-files = { paths = ["LICENSE"] }
 
 [project.optional-dependencies]
-git_support = ["gitpython"]
 pip_support = ["poetry ==1.1.*"]
 
 [project.scripts]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -27,3 +27,4 @@ mkdocs-click
 mkdocs-include-markdown-plugin
 flaky
 docker
+gitpython

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,6 @@ pyyaml >= 5.1
 ruamel.yaml
 tomli; python_version<"3.11"
 typing-extensions
-gitpython
 toolz >=0.12.0,<1.0.0
 # poetry:
 cachecontrol[filecache] >=0.12.9


### PR DESCRIPTION
## References
- fixes #296

## Changes
- move `gitpython` from `requirements.txt` to `requirements-dev.txt`
- return `None` when creating `GitMeta` if `gitpython` is not installed