### PR TITLE
fix #292: by not exporting empty CONDA_OVERRIDE_* variables

### DIFF
--- a/conda_lock/invoke_conda.py
+++ b/conda_lock/invoke_conda.py
@@ -158,7 +158,11 @@ def _process_stdout(stdout: IO[str]) -> Iterator[str]:
 
 
 def conda_env_override(platform: str) -> Dict[str, str]:
-    env = dict(os.environ)
+    env = {
+        key: val
+        for key, val in os.environ.items()
+        if not (key.startswith("CONDA_OVERRIDE_") and val == "")
+    }
     env.update(
         {
             "CONDA_SUBDIR": platform,


### PR DESCRIPTION
Should be one way to fix #292 - now conda=22.11 produces the same lockfile as conda=22.9.