### PR TITLE
Update header cmdlines in generated lockfiles (#518)

### DIFF
--- a/conda_lock/lockfile/__init__.py
+++ b/conda_lock/lockfile/__init__.py
@@ -187,14 +187,14 @@ def write_conda_lock_file(
                 available, unless you explicitly update the lock file.
 
                 Install this environment as "YOURENV" with:
-                    conda-lock install -n YOURENV --file {path.name}
+                    conda-lock install -n YOURENV {path.name}
                 """
             )
             if "dev" in categories:
                 write_section(
                     f"""
                     This lock contains optional development dependencies. Include them in the installed environment with:
-                        conda-lock install --dev-dependencies -n YOURENV --file {path.name}
+                        conda-lock install --dev-dependencies -n YOURENV {path.name}
                     """
                 )
             extras = sorted(categories.difference({"main", "dev"}))
@@ -202,7 +202,7 @@ def write_conda_lock_file(
                 write_section(
                     f"""
                     This lock contains optional dependency categories {', '.join(extras)}. Include them in the installed environment with:
-                        conda-lock install {' '.join('-e '+extra for extra in extras)} -n YOURENV --file {path.name}
+                        conda-lock install {' '.join('-e '+extra for extra in extras)} -n YOURENV {path.name}
                     """
                 )
             write_section(


### PR DESCRIPTION
Command lines suggested for install of the generated lockfile, which are put in the header of the generated lockfile, incorrectly suggest the use of a `--file` argument.

`--file` is no longer an option in the conda-lock CLI.  The lockfile is a positional parameter.

fixes #518

<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
