### PR TITLE
Replace logger.warn w/ logger.warning

### DIFF
--- a/conda_lock/conda_solver.py
+++ b/conda_lock/conda_solver.py
@@ -230,12 +230,12 @@ def _get_repodata_record(
                 with open(record) as f:
                     repodata: FetchAction = json.load(f)
                 return repodata
-        logger.warn(
+        logger.warning(
             f"Failed to find repodata_record.json for {dist_name}. "
             f"Retrying in 0.1 seconds ({retry}/{NUM_RETRIES})"
         )
         time.sleep(0.1)
-    logger.warn(f"Failed to find repodata_record.json for {dist_name}. Giving up.")
+    logger.warning(f"Failed to find repodata_record.json for {dist_name}. Giving up.")
     return None
 
 


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

This replaces calls to `logger.warn` with `logger.warning`. The former has been deprecated since Python 3.3 and generates `DeprecationWarning`s that can make output particularly in debugging and testing more noisy than necessary.

Also see conda/conda#13963.

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
