### PR TITLE
Use PAT for PRs when updating lockfile

### DIFF
--- a/.github/workflows/update-lockfile.yaml
+++ b/.github/workflows/update-lockfile.yaml
@@ -45,7 +45,7 @@ jobs:
         # # One possible workaround is to specify a Personal Access Token (PAT).
         # # This PAT should have read-write permissions for "Pull Requests"
         # # and read-write permissions for "Contents".
-        # token: ${{ secrets.GH_PAT_FOR_PR }}
+        token: ${{ secrets.GH_PAT_FOR_PR }}
         commit-message: Relock dependencies
         title: Relock dependencies
         body: >


### PR DESCRIPTION
Otherwise the tests don't run

<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

I want tests to be triggered when auto-updating the lockfile. That way I can see whether dependency updates are breaking the tests.

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->



<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/.github/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/.github/blob/main/CONTRIBUTING.md -->
