### PR TITLE
Fix `input-hash` in `--filename-template`

### DIFF
--- a/conda_lock/conda_lock.py
+++ b/conda_lock/conda_lock.py
@@ -555,7 +555,7 @@ def do_render(
                 context = {
                     "platform": plat,
                     "dev-dependencies": str(include_dev_dependencies).lower(),
-                    "input-hash": lockfile.metadata.content_hash,
+                    "input-hash": lockfile.metadata.content_hash[plat],
                     "version": distribution("conda_lock").version,
                     "timestamp": datetime.datetime.now(datetime.timezone.utc).strftime(
                         "%Y%m%dT%H%M%SZ"


### PR DESCRIPTION
### Description

When using `input-hash` in the argument to `--filename-template` the resulting filename contains not only the hash but the `__str__` (or maybe `__repr__`) value of the dict _item_.

This happens in v3.0.4 (installed via pip) and in 2b71e9dfd368.

For example:
```shell
$ uv run conda-lock -k explicit --filename-template "specific-{platform}-{input-hash}.conda.lock" -f conda-env.yml -p linux-64
Locking dependencies for ['linux-64']...
INFO:conda_lock.conda_solver:linux-64 using specs ['adapterremoval 2.3.4.*']
Rendering lockfile(s) for linux-64...
 - Install lock using : conda create --name YOURENV --file specific-linux-64-{'linux-64': 'a41b4291769e02a7d798ba7038818a260e55ddb1f8596f44d4b7f2f3e6cdaa8a'}.conda.lock
$ ls
conda-env.yml
specific-linux-64.conda.lock
'specific-linux-64-{'\''linux-64'\'': \''a41b4291769e02a7d798ba7038818a260e55ddb1f8596f44d4b7f2f3e6cdaa8a'\''}.conda.lock'
```

with the change in this PR, the output file is named `specific-linux-64-a41b4291769e02a7d798ba7038818a260e55ddb1f8596f44d4b7f2f3e6cdaa8a.conda.lock`, which I assume is what is intended. (It is what I wanted and expected).
