### PR TITLE
Add manylinux_2_34 to supported MANYLINUX_TAGS

### DIFF
--- a/conda_lock/content_hash.py
+++ b/conda_lock/content_hash.py
@@ -159,6 +159,43 @@ def _virtual_package_content_for_platform(
     return result
 
 
+def _replace_glibc_version(
+    virtual_package_repo: FakeRepoData,
+    platform: PlatformSubdirStr,
+    target_version: str,
+) -> FakeRepoData | None:
+    """Create a VPR variant with a different glibc version.
+
+    Returns None if the platform has no glibc package or already matches.
+    """
+    import copy
+
+    repodata = virtual_package_repo.all_repodata
+    if platform not in repodata:
+        return None
+    subdir_data = repodata[platform]
+    if not isinstance(subdir_data, dict) or "packages" not in subdir_data:
+        return None
+    packages = subdir_data["packages"]
+    # Find the glibc package key
+    glibc_keys = [k for k in packages if k.startswith("__glibc-")]
+    if not glibc_keys:
+        return None
+    glibc_key = glibc_keys[0]
+    current_version = packages[glibc_key].get("version")
+    if current_version == target_version:
+        return None
+
+    new_repo = copy.deepcopy(virtual_package_repo)
+    new_packages = new_repo.all_repodata[platform]["packages"]  # type: ignore[index]
+    # Remove old key, add new one
+    old_pkg = new_packages.pop(glibc_key)
+    new_key = f"__glibc-{target_version}-0.tar.bz2"
+    old_pkg["version"] = target_version
+    new_packages[new_key] = old_pkg
+    return new_repo
+
+
 def backwards_compatible_content_hashes(
     lock_spec: LockSpecification,
     virtual_package_repo: FakeRepoData | None,
@@ -190,6 +227,13 @@ def backwards_compatible_content_hashes(
     for vpr in virtual_package_repo_variants.copy():
         if platform == "osx-64" and _contains_osx_11_0_0_tar_bz2(vpr):
             virtual_package_repo_variants.append(add_or_remove_osx_10_15_0_tar_bz2(vpr))
+
+    # Support previous default glibc version (2.28) for backwards compatibility.
+    for vpr in virtual_package_repo_variants.copy():
+        if platform.startswith("linux"):
+            variant = _replace_glibc_version(vpr, platform, "2.28")
+            if variant is not None:
+                virtual_package_repo_variants.append(variant)
 
     # Reinsert spurious build number in build string
     for vpr in virtual_package_repo_variants.copy():

--- a/conda_lock/content_hash.py
+++ b/conda_lock/content_hash.py
@@ -168,8 +168,6 @@ def _replace_glibc_version(
 
     Returns None if the platform has no glibc package or already matches.
     """
-    import copy
-
     repodata = virtual_package_repo.all_repodata
     if platform not in repodata:
         return None
@@ -186,8 +184,9 @@ def _replace_glibc_version(
     if current_version == target_version:
         return None
 
-    new_repo = copy.deepcopy(virtual_package_repo)
-    new_packages = new_repo.all_repodata[platform]["packages"]  # type: ignore[index]
+    new_repo = virtual_package_repo.model_copy(deep=True)
+    new_subdir = cast(SubdirMetadata, new_repo.all_repodata[platform])
+    new_packages = new_subdir["packages"]
     # Remove old key, add new one
     old_pkg = new_packages.pop(glibc_key)
     new_key = f"__glibc-{target_version}-0.tar.bz2"

--- a/conda_lock/default-virtual-packages.yaml
+++ b/conda_lock/default-virtual-packages.yaml
@@ -5,7 +5,7 @@ subdirs:
       __linux: "5.10"
       __archspec: "1 x86_64"
       # NOTE: Keep this in sync with the MANYLINUX_TAGS maximum in pypi_solver.py
-      __glibc: "2.28"
+      __glibc: "2.34"
       __cuda: "11.4"
   linux-aarch64:
     packages:
@@ -13,7 +13,7 @@ subdirs:
       __linux: "5.10"
       __archspec: "1 aarch64"
       # NOTE: Keep this in sync with the MANYLINUX_TAGS maximum in pypi_solver.py
-      __glibc: "2.28"
+      __glibc: "2.34"
       __cuda: "11.4"
   linux-ppc64le:
     packages:
@@ -21,7 +21,7 @@ subdirs:
       __linux: "5.10"
       __archspec: "1 ppc64le"
       # NOTE: Keep this in sync with the MANYLINUX_TAGS maximum in pypi_solver.py
-      __glibc: "2.28"
+      __glibc: "2.34"
       __cuda: "11.4"
   osx-64:
     packages:

--- a/conda_lock/pypi_solver.py
+++ b/conda_lock/pypi_solver.py
@@ -60,7 +60,7 @@ if TYPE_CHECKING:
 # in practice, see https://github.com/pypa/manylinux/blob/main/README.rst#docker-images.
 # NOTE:
 #   Keep the max in sync with the default value used in default-virtual-packages.yaml.
-MANYLINUX_TAGS = ["1", "2010", "2014", "_2_17", "_2_18", "_2_24", "_2_28"]
+MANYLINUX_TAGS = ["1", "2010", "2014", "_2_17", "_2_18", "_2_24", "_2_28", "_2_34"]
 
 # This needs to be updated periodically as new macOS versions are released.
 MACOS_VERSION = (13, 4)

--- a/tests/test-v2-to-v3-upgrade/test_v2_to_v3_upgrade.py
+++ b/tests/test-v2-to-v3-upgrade/test_v2_to_v3_upgrade.py
@@ -10,9 +10,9 @@ from conda_lock.virtual_package import default_virtual_package_repodata
 
 
 HASHES_V2 = {
-    "linux-64": "4e3086c79ebb7044f221959819fbca22e3ad4144b2723482e48f2cffef1cb948",
-    "linux-aarch64": "07b90c11b3b0bb858767afd42d753952d0f1c6df852771b0d5d2d3f495628cfa",
-    "linux-ppc64le": "39107ca32794f20f9b443d2d44862b5d06184164df3f851f56901fd0d69483e9",
+    "linux-64": "4a34c25ae4fa250951e1774ca78c8e5fb2c0bb7d49b07bd4db5047ef8c2bdf0c",
+    "linux-aarch64": "a53a32b3676ee7b987d8ba9c816e79483df8b7f8008357edc8bc461b048c3e60",
+    "linux-ppc64le": "73ae6c8ac4d770826d61fd1dcfc0606d2e0a176601105f4171c1cb8d8eb9fd1a",
     "osx-64": "d8bfcbde7a20bc50b27ca25139f0d18ee48d21905c7482722c120793713144b1",
     "osx-arm64": "e5b0208328748fdbbf872160bf8e5aff48d3fd5f38fde26e12dcd72a32d5a0d7",
     "win-64": "a67c2def7fa06f94d92df2f17e7c7c940efbb0998a92788a2c1c4feddd605579",

--- a/tests/test_conda_lock.py
+++ b/tests/test_conda_lock.py
@@ -2811,9 +2811,9 @@ def test_default_virtual_package_input_hash_stability():
 
     # This is the hash that conda-lock v2 would produce.
     expected = {
-        "linux-64": "a949aac83da089258ce729fcd54dc0a3a1724ea325d67680d7a6d7cc9c0f1d1b",
-        "linux-aarch64": "f68603a3a28dbb03d20a25e1dacda3c42b6acc8a93bd31e13c4956115820cfa6",
-        "linux-ppc64le": "ababb6bc556ac8c9e27a499bf9b83b5757f6ded385caa0c3d7bf3f360dfe358d",
+        "linux-64": "52b368abeebb42b6420c2e2270d0d17aad5278f193df982f72d5a2a3f080e408",
+        "linux-aarch64": "c01736931af8f26c78029c21f7839374e5679e0dc92a008ac5e242d4ab5191fa",
+        "linux-ppc64le": "034bc18c326a8d65a8529e46b348557fddfadc485f6afb334f4bc0e8b76ed408",
         "osx-64": "b7eebe4be0654740f67e3023f2ede298f390119ef225f50ad7e7288ea22d5c93",
         "osx-arm64": "cc82018d1b1809b9aebacacc5ed05ee6a4318b3eba039607d2a6957571f8bf2b",
         "win-64": "44239e9f0175404e62e4a80bb8f4be72e38c536280d6d5e484e52fa04b45c9f6",
@@ -2826,8 +2826,10 @@ def test_default_virtual_package_input_hash_stability():
     vpr = default_virtual_package_repodata()
     assert compute_content_hashes(spec, vpr) == expected
 
-    # This is the hash that conda-lock v3.0.0, v3.0.1, and v3.0.2 would produce.
-    expected = {
+    # These are hashes from prior conda-lock versions that should still be
+    # recognized as valid (backwards compatibility).
+    # v3.0.0, v3.0.1, v3.0.2:
+    old_expected = {
         "linux-64": "ebfbb8130f916103373e6521bfb129825cded8b0c3e93f430cc834d8c3664244",
         "linux-aarch64": "5418156c9b6c5ae92b8558087b5d39ee06c66b5ec405a91b4c7ee23d6cec41e2",
         "linux-ppc64le": "7b111d5f69fb0bd81808d1a9272187ad719e5f03c63b3ebb600aca01355b8576",
@@ -2835,7 +2837,16 @@ def test_default_virtual_package_input_hash_stability():
         "osx-arm64": "bb227bce8532d0eee9396306045e270525b110103f4c54be9ac35621baab3dcd",
         "win-64": "1d34ea90abc99d31721cae03335543cbe16ad4e1eaa988e7a7f8563bda2f951d",
     }
-    for platform, hash in expected.items():
+    for platform, hash in old_expected.items():
+        assert hash in backwards_compatible_content_hashes(spec, vpr, platform)
+
+    # v4.x with glibc 2.28 defaults:
+    old_expected_v4 = {
+        "linux-64": "a949aac83da089258ce729fcd54dc0a3a1724ea325d67680d7a6d7cc9c0f1d1b",
+        "linux-aarch64": "f68603a3a28dbb03d20a25e1dacda3c42b6acc8a93bd31e13c4956115820cfa6",
+        "linux-ppc64le": "ababb6bc556ac8c9e27a499bf9b83b5757f6ded385caa0c3d7bf3f360dfe358d",
+    }
+    for platform, hash in old_expected_v4.items():
         assert hash in backwards_compatible_content_hashes(spec, vpr, platform)
 
 
@@ -2846,9 +2857,9 @@ def test_default_virtual_package_input_hash_stability_cuda_version():
 
     # This is the hash that conda-lock v2 would produce.
     expected = {
-        "linux-64": "0257887bdd38bfe371e508a3d00710f82bcc0ffa06ae87a088aa2854fb6f5525",
-        "linux-aarch64": "4c3242ac2adfe9f8d3e34b377db8da48a834c7a3a126cfa84e385cf1bd6bc55f",
-        "linux-ppc64le": "f551f44ac5ea6e3155a05ad2b024049f93857043c44df5a067cc0207d99b397d",
+        "linux-64": "7741c27907f5eac35bc0a798bb878bb6af604e22c3695b42d0898285c77b3aa7",
+        "linux-aarch64": "0e01d9148c215806089dab34ba7b5a66c9aed4314e7e688ea7c387aba7dcc738",
+        "linux-ppc64le": "aa5a655940adec562ae79c0ea160b97d8acce4a49ddd3d8d241d7c340dda8d66",
         "osx-64": "b7eebe4be0654740f67e3023f2ede298f390119ef225f50ad7e7288ea22d5c93",
         "osx-arm64": "cc82018d1b1809b9aebacacc5ed05ee6a4318b3eba039607d2a6957571f8bf2b",
         "win-64": "cf8f3a86e85e953c5a760709b9485c2035de349350924d9f38dfd3161b41842b",
@@ -2861,8 +2872,8 @@ def test_default_virtual_package_input_hash_stability_cuda_version():
     vpr = default_virtual_package_repodata(cuda_version=CUDA_VERSION)
     assert compute_content_hashes(spec, vpr) == expected
 
-    # This is the hash that conda-lock v3.0.0, v3.0.1, and v3.0.2 would produce.
-    expected = {
+    # v3.0.0, v3.0.1, v3.0.2:
+    old_expected = {
         "linux-64": "3e46169a88764ee0b4c1a906bb8bb4e47ee346f2d3fcca166d144615f76c7b4f",
         "linux-aarch64": "9548afc17f91da634ae3b841313f1a7bd5596fbfea35e5597d2eb599c4317d2f",
         "linux-ppc64le": "2a9e00acf651dc0bbb19a12b076388616c90257b37a76ef5c5fb9ed669986157",
@@ -2870,7 +2881,16 @@ def test_default_virtual_package_input_hash_stability_cuda_version():
         "osx-arm64": "bb227bce8532d0eee9396306045e270525b110103f4c54be9ac35621baab3dcd",
         "win-64": "c1effdfa1f4ce1f8c63c64c02d2b395801f792a45dff966c72fa7e36126a7bd7",
     }
-    for platform, hash in expected.items():
+    for platform, hash in old_expected.items():
+        assert hash in backwards_compatible_content_hashes(spec, vpr, platform)
+
+    # v4.x with glibc 2.28 defaults:
+    old_expected_v4 = {
+        "linux-64": "0257887bdd38bfe371e508a3d00710f82bcc0ffa06ae87a088aa2854fb6f5525",
+        "linux-aarch64": "4c3242ac2adfe9f8d3e34b377db8da48a834c7a3a126cfa84e385cf1bd6bc55f",
+        "linux-ppc64le": "f551f44ac5ea6e3155a05ad2b024049f93857043c44df5a067cc0207d99b397d",
+    }
+    for platform, hash in old_expected_v4.items():
         assert hash in backwards_compatible_content_hashes(spec, vpr, platform)
 
 


### PR DESCRIPTION
## Summary

- Adds `_2_34` to `MANYLINUX_TAGS` in `pypi_solver.py`
- Bumps default `__glibc` from `2.28` to `2.34` in `default-virtual-packages.yaml` for all Linux subdirs

Follow-up to #847, which added `_2_18`.

## Motivation

[pyqir 0.12.3](https://pypi.org/project/pyqir/0.12.3/#files) only publishes Linux wheels for `manylinux_2_34` (x86_64) and `manylinux_2_38` (aarch64). Since `MANYLINUX_TAGS` currently maxes out at `_2_28`, conda-lock's PyPI solver rejects these wheels:

```
RuntimeError: Unable to find installation candidates for pyqir (0.12.3)
```

The `--virtual-package-spec` workaround doesn't help because even if `__glibc` is set to `2.34`, the hardcoded tag list doesn't include `_2_34`.

## Discussion

I'm open to discussing a better long-term solution — e.g., dynamically generating valid manylinux tags from the glibc version rather than maintaining a hardcoded list. Happy to iterate on this.

## Test plan

- [ ] Verify pyqir 0.12.3 resolves successfully for linux-64
- [ ] Verify `--virtual-package-spec` with `__glibc: "2.34"` works end-to-end
- [ ] Verify backward compatibility (packages with older manylinux tags still resolve)