### PR TITLE
Decouple default glibc from MANYLINUX_TAGS maximum

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,15 @@ Conda makes use of [virtual packages](https://conda.io/projects/conda/en/latest/
 runtime to gate dependency on system features.  Due to these not generally existing on your local execution platform conda-lock will inject
 them into the solution environment with a reasonable guess at what a default system configuration should be.
 
+Each virtual package version represents an assumed minimum system capability. The solver
+excludes any package that requires a newer version, so these act as upper bounds on which
+packages are considered. Conversely, they act as lower bounds on the systems where the
+resulting lockfile can be installed.
+
+There is a tradeoff: increasing a version widens the set of candidate packages but narrows
+the set of compatible target systems.  If a package you need is being filtered out, increase the
+relevant version.  If the lockfile is incompatible with your target system, decrease it.
+
 If you want to override which virtual packages are injected you can create a file like
 
 ```yaml

--- a/README.md
+++ b/README.md
@@ -244,20 +244,21 @@ conda-lock install --auth-file auth.json conda-linux-64.lock
 
 ### --virtual-package-spec
 
-Conda makes use of [virtual packages](https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-virtual.html) that are available at
-runtime to gate dependency on system features.  Due to these not generally existing on your local execution platform conda-lock will inject
-them into the solution environment with a reasonable guess at what a default system configuration should be.
+Conda uses [virtual packages](https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-virtual.html) to describe system-level
+features like the glibc version, macOS version, or CUDA version.  Since conda-lock generates
+lockfiles independently of a target system, it assumes a default set of virtual package versions
+that represent a reasonable minimum system configuration.
 
-Each virtual package version represents an assumed minimum system capability. The solver
-excludes any package that requires a newer version, so these act as upper bounds on which
-packages are considered. Conversely, they act as lower bounds on the systems where the
-resulting lockfile can be installed.
+Each virtual package version acts as an upper bound on which packages are considered by
+the solver (packages requiring a newer version are excluded) and as a lower bound on
+compatible target systems (the lockfile is installable on systems that meet or exceed
+these versions).
 
 There is a tradeoff: increasing a version widens the set of candidate packages but narrows
 the set of compatible target systems.  If a package you need is being filtered out, increase the
 relevant version.  If the lockfile is incompatible with your target system, decrease it.
 
-If you want to override which virtual packages are injected you can create a file like
+To override the defaults, create a `virtual-packages.yml` file like
 
 ```yaml
 # virtual-packages.yml

--- a/conda_lock/default-virtual-packages.yaml
+++ b/conda_lock/default-virtual-packages.yaml
@@ -1,3 +1,19 @@
+# Default virtual packages used when no --virtual-package-spec is provided.
+#
+# Each version represents the assumed minimum system capability. The solver
+# filters out any package that requires a newer version, so these act as upper
+# bounds on which packages are considered. Conversely, they act as lower bounds
+# on the systems where the resulting lockfile can be installed.
+#
+# For example, with __glibc: "2.28", packages requiring glibc > 2.28 are
+# excluded from the lockfile, and the lockfile is installable on any system
+# with glibc >= 2.28.
+#
+# Tradeoff: increasing a version widens the set of candidate packages but
+# narrows the set of compatible target systems. If a package you need is being
+# filtered out, increase the version. If the lockfile is incompatible with your
+# target system, decrease the version. To override these defaults, create a
+# virtual-packages.yml file (see README.md).
 subdirs:
   linux-64:
     packages:

--- a/conda_lock/default-virtual-packages.yaml
+++ b/conda_lock/default-virtual-packages.yaml
@@ -4,7 +4,6 @@ subdirs:
       __unix: "0"
       __linux: "5.10"
       __archspec: "1 x86_64"
-      # NOTE: Keep this in sync with the MANYLINUX_TAGS maximum in pypi_solver.py
       __glibc: "2.28"
       __cuda: "11.4"
   linux-aarch64:
@@ -12,7 +11,6 @@ subdirs:
       __unix: "0"
       __linux: "5.10"
       __archspec: "1 aarch64"
-      # NOTE: Keep this in sync with the MANYLINUX_TAGS maximum in pypi_solver.py
       __glibc: "2.28"
       __cuda: "11.4"
   linux-ppc64le:
@@ -20,7 +18,6 @@ subdirs:
       __unix: "0"
       __linux: "5.10"
       __archspec: "1 ppc64le"
-      # NOTE: Keep this in sync with the MANYLINUX_TAGS maximum in pypi_solver.py
       __glibc: "2.28"
       __cuda: "11.4"
   osx-64:

--- a/conda_lock/pypi_solver.py
+++ b/conda_lock/pypi_solver.py
@@ -58,8 +58,6 @@ if TYPE_CHECKING:
 # NB: in principle these depend on the glibc on the machine creating the conda env.
 # We use tags supported by manylinux Docker images, which are likely the most common
 # in practice, see https://github.com/pypa/manylinux/blob/main/README.rst#docker-images.
-# NOTE:
-#   Keep the max in sync with the default value used in default-virtual-packages.yaml.
 MANYLINUX_TAGS = ["1", "2010", "2014", "_2_17", "_2_18", "_2_24", "_2_28"]
 
 # This needs to be updated periodically as new macOS versions are released.

--- a/docs/flags.md
+++ b/docs/flags.md
@@ -135,11 +135,21 @@ When the input_hash of the input files, channels match those present in a given 
 
 ## --virtual-package-spec
 
-Conda makes use of [virtual packages](https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-virtual.html) that are available at
-runtime to gate dependency on system features.  Due to these not generally existing on your local execution platform conda-lock will inject
-them into the solution environment with a reasonable guess at what a default system configuration should be.
+Conda uses [virtual packages](https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-virtual.html) to describe system-level
+features like the glibc version, macOS version, or CUDA version.  Since conda-lock generates
+lockfiles independently of a target system, it assumes a default set of virtual package versions
+that represent a reasonable minimum system configuration.
 
-If you want to override which virtual packages are injected you can create a virtual package spec file
+Each virtual package version acts as an upper bound on which packages are considered by
+the solver (packages requiring a newer version are excluded) and as a lower bound on
+compatible target systems (the lockfile is installable on systems that meet or exceed
+these versions).
+
+There is a tradeoff: increasing a version widens the set of candidate packages but narrows
+the set of compatible target systems.  If a package you need is being filtered out, increase the
+relevant version.  If the lockfile is incompatible with your target system, decrease it.
+
+To override the defaults, create a virtual package spec file
 
 ```{.yaml title="virtual-packages.yml"}
 subdirs:

--- a/tests/test_conda_lock.py
+++ b/tests/test_conda_lock.py
@@ -3258,15 +3258,17 @@ def test_manylinux_tags():
     assert versions[0] == Version("2.17")
     assert versions == sorted(versions)
 
-    # Verify that the default repodata uses the highest glibc version
+    # Verify that the default glibc versions are covered by MANYLINUX_TAGS.
+    # (The default may be lower than the max tag; higher tags are available
+    # via --virtual-package-spec.)
     default_repodata = default_virtual_package_repodata()
     glibc_versions_in_default_repodata: set[Version] = {
         Version(package.version)
         for package in default_repodata.packages_by_subdir
         if package.name == "__glibc"
     }
-    max_glibc_version_from_manylinux_tags = versions[-1]
-    assert glibc_versions_in_default_repodata == {max_glibc_version_from_manylinux_tags}
+    manylinux_glibc_versions = set(versions)
+    assert glibc_versions_in_default_repodata <= manylinux_glibc_versions
 
 
 def test_pip_respects_glibc_version(


### PR DESCRIPTION
Human-written content:

Back in the day, @romain-intel and I added a test in #566 that in retrospect I believe was in error. The problem is "Verify that the default repodata uses the highest glibc version" in [`test_manylinux_tags`](https://github.com/conda/conda-lock/pull/566/changes#diff-16ef30c79cbf7680f16049dae056e40c1a71d8409b275fe35edad859a8ddc097R2471-R2479) because it imposes what I believe is an artificial constraint on the glibc version: that the default glibc version must track the latest glibc version.

In order to understand why I believe this constraint is artificial, it's necessary to have a clear view of what the virtual package versions represent. I personally find the concept very confusing. Thinking hard about what I found confusing, realized that it's because the versions specified are functioning simultaneously as an upper-bound (for filtering) and a lower-bound (for system compatibility), and hence represent a tradeoff. I tried to rewrite the documentation in plain language to make it easier to understand the crux:

> Each virtual package version acts as an upper bound on which packages are considered by
the solver (packages requiring a newer version are excluded) and as a lower bound on
compatible target systems (the lockfile is installable on systems that meet or exceed
these versions).
>
>There is a tradeoff: increasing a version widens the set of candidate packages but narrows
the set of compatible target systems.  If a package you need is being filtered out, increase the
relevant version.  If the lockfile is incompatible with your target system, decrease it.

So the problem I see with the test is that if we max out the default virtual package glibc version, then we generate lockfiles that may contain packages that require this high glibc version, and hence are uninstallable on systems for which the glibc version is lagging. I believe the optimal default virtual package versions should be a middle ground to avoid both tradeoff extremes.

I don't think we should increase the default glibc version as part of #900, and looking at why the version was bumped there, I believe it was due to this test. So I'm hoping here to fix the root cause of the confusion via documentation, and also to fix the test so that the right compromise remains possible with the defaults.

---

LLM content:

## Summary

- Relax `test_manylinux_tags` assertion from `==` to set inclusion (`<=`): the default glibc versions must be covered by `MANYLINUX_TAGS`, but the max tag can exceed the default
- Remove misleading "Keep this in sync with the MANYLINUX_TAGS maximum" comments
- Document virtual package version semantics in `default-virtual-packages.yaml`, `README.md`, and `docs/flags.md`

## Motivation

The previous test and comments incorrectly coupled two independent concerns:

1. **Default glibc** (`default-virtual-packages.yaml`): a conservative assumption about the target system — should be kept low (e.g., 2.28, matching [Pixi's default](https://pixi.sh/latest/workspace/system_requirements/#default-system-requirements))
2. **MANYLINUX_TAGS maximum** (`pypi_solver.py`): the highest manylinux tag the solver understands — can be higher than the default, since users can opt in via `--virtual-package-spec`

The old invariant forced contributors to bump the default glibc whenever adding a new manylinux tag (see #900), which would silently change solver behavior for all users and risk producing lockfiles incompatible with older glibc systems.

The correct invariant is: every default glibc version must appear in `MANYLINUX_TAGS` (set inclusion), but the max tag can exceed the default.

Context: #847 (discussion about dynamically generating tags), #566 (original manylinux filtering), #900 (motivated this fix)

## Test plan

- [x] `test_manylinux_tags` passes with the relaxed assertion
- [x] All pre-commit hooks pass
- [x] No content hash changes (comments in YAML don't affect hashes)

Made with [Cursor](https://cursor.com)