### PR TITLE
fix: register as conda plugin

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -39,6 +39,10 @@ jobs:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
         python-version: [ "3.10", "3.14" ]
         use_conda_cli: ["false", "true"]
+        exclude:
+          - os: windows-latest
+            python-version: "3.14"
+            use_conda_cli: "true"
     steps:
       - name: Set Conda platform
         run: |
@@ -119,6 +123,10 @@ jobs:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
         python-version: [ "3.10", "3.14" ]
         use_conda_cli: ["false", "true"]
+        exclude:
+          - os: windows-latest
+            python-version: "3.14"
+            use_conda_cli: "true"
     steps:
       - name: Set Conda platform
         run: |
@@ -169,6 +177,10 @@ jobs:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
         python-version: [ "3.10", "3.14" ]
         use_conda_cli: ["false", "true"]
+        exclude:
+          - os: windows-latest
+            python-version: "3.14"
+            use_conda_cli: "true"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -217,6 +229,10 @@ jobs:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
         python-version: [ "3.10", "3.14" ]
         use_conda_cli: ["false", "true"]
+        exclude:
+          - os: windows-latest
+            python-version: "3.14"
+            use_conda_cli: "true"
     steps:
       - uses: conda-incubator/setup-miniconda@fc2d68f6413eb2d87b895e92f8584b5b94a10167 # v3.3.0
         with:

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -86,7 +86,7 @@ jobs:
         if: matrix.use_conda_cli == 'true'
         shell: bash -leo pipefail {0}
         run: |
-          conda install pip setuptools hatchling hatch-vcs conda-lock --yes
+          conda install pip setuptools editables hatchling hatch-vcs conda-lock --yes
           conda uninstall conda-lock --force --yes
           pip install --no-deps --no-build-isolation -e .
       - name: run-test

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -38,11 +38,6 @@ jobs:
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
         python-version: [ "3.10", "3.14" ]
-        use_conda_cli: ["false", "true"]
-        exclude:
-          - os: windows-latest
-            python-version: "3.14"
-            use_conda_cli: "true"
     steps:
       - name: Set Conda platform
         run: |
@@ -60,17 +55,14 @@ jobs:
         with:
           persist-credentials: false
       - name: Set up Python
-        if: matrix.use_conda_cli == 'false'
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: install conda-lock
-        if: matrix.use_conda_cli == 'false'
         run: |
           pip install pipx
           pipx install -e .
       - name: run-test
-        if: matrix.use_conda_cli == 'false'
         run: |
           conda-lock --log-level=DEBUG --micromamba -f tests/gdal/environment.yml -p $CONDA_PLATFORM
           conda-lock render -p $CONDA_PLATFORM
@@ -80,35 +72,10 @@ jobs:
           cat conda-lock.yml
           mkdir lockfiles
           mv conda-$CONDA_PLATFORM.lock conda-$CONDA_PLATFORM.lock.yml conda-lock.yml lockfiles
-      - name: Set up Python
-        if: matrix.use_conda_cli == 'true'
-        uses: conda-incubator/setup-miniconda@fc2d68f6413eb2d87b895e92f8584b5b94a10167 # v3.3.0
-        with:
-          auto-activate-base: true
-          python-version: ${{ matrix.python-version }}
-      - name: install conda-lock
-        if: matrix.use_conda_cli == 'true'
-        shell: bash -leo pipefail {0}
-        run: |
-          conda install conda pip setuptools editables hatchling hatch-vcs conda-lock --yes
-          conda uninstall conda-lock --force --yes
-          pip install --no-deps --no-build-isolation -e .
-      - name: run-test
-        if: matrix.use_conda_cli == 'true'
-        shell: bash -leo pipefail {0}
-        run: |
-          python -m conda lock --log-level=DEBUG --micromamba -f tests/gdal/environment.yml -p $CONDA_PLATFORM
-          python -m conda lock render -p $CONDA_PLATFORM
-          python -m conda lock render -p $CONDA_PLATFORM --kind=env
-          cat conda-$CONDA_PLATFORM.lock
-          cat conda-$CONDA_PLATFORM.lock.yml
-          cat conda-lock.yml
-          mkdir lockfiles
-          mv conda-$CONDA_PLATFORM.lock conda-$CONDA_PLATFORM.lock.yml conda-lock.yml lockfiles
       - name: Upload lockfiles
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
-          name: conda-lock-${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.use_conda_cli }}
+          name: conda-lock-${{ matrix.os }}-${{ matrix.python-version }}
           path: lockfiles
 
   install-gdal-with-micromamba:
@@ -122,11 +89,6 @@ jobs:
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
         python-version: [ "3.10", "3.14" ]
-        use_conda_cli: ["false", "true"]
-        exclude:
-          - os: windows-latest
-            python-version: "3.14"
-            use_conda_cli: "true"
     steps:
       - name: Set Conda platform
         run: |
@@ -149,7 +111,7 @@ jobs:
       - name: Download lockfiles
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
-          name: conda-lock-${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.use_conda_cli }}
+          name: conda-lock-${{ matrix.os }}-${{ matrix.python-version }}
           path: lockfiles
       - name: Install GDAL with Micromamba
         run: |
@@ -176,11 +138,6 @@ jobs:
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
         python-version: [ "3.10", "3.14" ]
-        use_conda_cli: ["false", "true"]
-        exclude:
-          - os: windows-latest
-            python-version: "3.14"
-            use_conda_cli: "true"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -196,7 +153,7 @@ jobs:
       - name: Download lockfiles
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
-          name: conda-lock-${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.use_conda_cli }}
+          name: conda-lock-${{ matrix.os }}-${{ matrix.python-version }}
           path: lockfiles
       - name: Install GDAL with conda-lock
         run: |
@@ -228,11 +185,6 @@ jobs:
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
         python-version: [ "3.10", "3.14" ]
-        use_conda_cli: ["false", "true"]
-        exclude:
-          - os: windows-latest
-            python-version: "3.14"
-            use_conda_cli: "true"
     steps:
       - uses: conda-incubator/setup-miniconda@fc2d68f6413eb2d87b895e92f8584b5b94a10167 # v3.3.0
         with:
@@ -241,7 +193,7 @@ jobs:
       - name: Download lockfiles
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
-          name: conda-lock-${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.use_conda_cli }}
+          name: conda-lock-${{ matrix.os }}-${{ matrix.python-version }}
           path: lockfiles
       - name: Install GDAL with conda
         run: |
@@ -258,3 +210,39 @@ jobs:
 
           # conda doesn't install pip dependencies from explicit lockfiles, so skip this test
           conda run -n gdal-test-c-env python -c 'import toolz; print(toolz.__version__)'
+
+  lock-gdal-via-conda:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Set Conda platform
+        run: |
+          echo "CONDA_PLATFORM=linux-64" >> $GITHUB_ENV
+      - name: Verify Conda platform
+        run: echo "Conda platform is $CONDA_PLATFORM"
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Set up Conda
+        uses: conda-incubator/setup-miniconda@fc2d68f6413eb2d87b895e92f8584b5b94a10167 # v3.3.0
+        with:
+          auto-activate-base: true
+          python-version: 3.14
+      - name: install conda-lock
+        shell: bash -leo pipefail {0}
+        run: |
+          conda install conda pip setuptools editables hatchling hatch-vcs conda-lock --yes
+          conda uninstall conda-lock --force --yes
+          pip install --no-deps --no-build-isolation -e .
+      - name: run-test
+        shell: bash -leo pipefail {0}
+        run: |
+          python -m conda lock --help
+          python -m conda lock lock --help
+          python -m conda lock --log-level=DEBUG --micromamba -f tests/gdal/environment.yml -p $CONDA_PLATFORM
+          python -m conda lock render -p $CONDA_PLATFORM
+          python -m conda lock render -p $CONDA_PLATFORM --kind=env
+          cat conda-$CONDA_PLATFORM.lock
+          cat conda-$CONDA_PLATFORM.lock.yml
+          cat conda-lock.yml

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -86,7 +86,7 @@ jobs:
         if: matrix.use_conda_cli == 'true'
         shell: bash -leo pipefail {0}
         run: |
-          conda install pip setuptools hatchling conda-lock --yes
+          conda install pip setuptools hatchling hatch-vcs conda-lock --yes
           conda uninstall conda-lock --force --yes
           pip install --no-deps --no-build-isolation -e .
       - name: run-test

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -77,7 +77,6 @@ jobs:
         with:
           name: conda-lock-${{ matrix.os }}-${{ matrix.python-version }}
           path: lockfiles
-
   install-gdal-with-micromamba:
     runs-on: ${{ matrix.os }}
     needs: lock-gdal
@@ -126,7 +125,6 @@ jobs:
           micromamba run -n gdal-test-mm-lock python -c 'import toolz; print(toolz.__version__)'
           # Micromamba won't install pip dependencies from explicit lockfiles, so skip this test
           micromamba run -n gdal-test-mm-env python -c 'import toolz; print(toolz.__version__)'
-
   install-gdal-with-conda-lock:
     runs-on: ${{ matrix.os }}
     needs: lock-gdal

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -86,7 +86,7 @@ jobs:
         if: matrix.use_conda_cli == 'true'
         shell: bash -leo pipefail {0}
         run: |
-          conda install pip setuptools conda-lock --yes
+          conda install pip setuptools hatchling conda-lock --yes
           conda uninstall conda-lock --force --yes
           pip install --no-deps --no-build-isolation -e .
       - name: run-test

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -38,6 +38,7 @@ jobs:
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
         python-version: [ "3.10", "3.14" ]
+        use_conda_cli: ["false", "true"]
     steps:
       - name: Set Conda platform
         run: |
@@ -55,14 +56,17 @@ jobs:
         with:
           persist-credentials: false
       - name: Set up Python
+        if: matrix.use_conda_cli == 'false'
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: install conda-lock
+        if: matrix.use_conda_cli == 'false'
         run: |
           pip install pipx
           pipx install -e .
       - name: run-test
+        if: matrix.use_conda_cli == 'false'
         run: |
           conda-lock --log-level=DEBUG --micromamba -f tests/gdal/environment.yml -p $CONDA_PLATFORM
           conda-lock render -p $CONDA_PLATFORM
@@ -72,11 +76,35 @@ jobs:
           cat conda-lock.yml
           mkdir lockfiles
           mv conda-$CONDA_PLATFORM.lock conda-$CONDA_PLATFORM.lock.yml conda-lock.yml lockfiles
+      - name: Set up Python
+        if: matrix.use_conda_cli == 'true'
+        uses: conda-incubator/setup-miniconda@fc2d68f6413eb2d87b895e92f8584b5b94a10167 # v3.3.0
+        with:
+          auto-activate-base: true
+          python-version: ${{ matrix.python-version }}
+      - name: install conda-lock
+        if: matrix.use_conda_cli == 'true'
+        run: |
+          conda install pip setuptools conda-lock --yes
+          conda uninstall conda-lock --force --yes
+          pip install --no-deps --no-build-isolation -e .
+      - name: run-test
+        if: matrix.use_conda_cli == 'true'
+        run: |
+          python -m conda lock --log-level=DEBUG --micromamba -f tests/gdal/environment.yml -p $CONDA_PLATFORM
+          python -m conda lock render -p $CONDA_PLATFORM
+          python -m conda lock render -p $CONDA_PLATFORM --kind=env
+          cat conda-$CONDA_PLATFORM.lock
+          cat conda-$CONDA_PLATFORM.lock.yml
+          cat conda-lock.yml
+          mkdir lockfiles
+          mv conda-$CONDA_PLATFORM.lock conda-$CONDA_PLATFORM.lock.yml conda-lock.yml lockfiles
       - name: Upload lockfiles
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
-          name: conda-lock-${{ matrix.os }}-${{ matrix.python-version }}
+          name: conda-lock-${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.use_conda_cli }}
           path: lockfiles
+
   install-gdal-with-micromamba:
     runs-on: ${{ matrix.os }}
     needs: lock-gdal
@@ -87,7 +115,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
-        python-version: [ "3.10" ]
+        python-version: [ "3.10", "3.14" ]
+        use_conda_cli: ["false", "true"]
     steps:
       - name: Set Conda platform
         run: |
@@ -110,7 +139,7 @@ jobs:
       - name: Download lockfiles
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
-          name: conda-lock-${{ matrix.os }}-${{ matrix.python-version }}
+          name: conda-lock-${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.use_conda_cli }}
           path: lockfiles
       - name: Install GDAL with Micromamba
         run: |
@@ -125,6 +154,7 @@ jobs:
           micromamba run -n gdal-test-mm-lock python -c 'import toolz; print(toolz.__version__)'
           # Micromamba won't install pip dependencies from explicit lockfiles, so skip this test
           micromamba run -n gdal-test-mm-env python -c 'import toolz; print(toolz.__version__)'
+
   install-gdal-with-conda-lock:
     runs-on: ${{ matrix.os }}
     needs: lock-gdal
@@ -136,6 +166,7 @@ jobs:
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
         python-version: [ "3.10", "3.14" ]
+        use_conda_cli: ["false", "true"]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -151,7 +182,7 @@ jobs:
       - name: Download lockfiles
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
-          name: conda-lock-${{ matrix.os }}-${{ matrix.python-version }}
+          name: conda-lock-${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.use_conda_cli }}
           path: lockfiles
       - name: Install GDAL with conda-lock
         run: |
@@ -182,7 +213,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
-        python-version: [ "3.10" ]
+        python-version: [ "3.10", "3.14" ]
+        use_conda_cli: ["false", "true"]
     steps:
       - uses: conda-incubator/setup-miniconda@fc2d68f6413eb2d87b895e92f8584b5b94a10167 # v3.3.0
         with:
@@ -191,7 +223,7 @@ jobs:
       - name: Download lockfiles
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
-          name: conda-lock-${{ matrix.os }}-${{ matrix.python-version }}
+          name: conda-lock-${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.use_conda_cli }}
           path: lockfiles
       - name: Install GDAL with conda
         run: |

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -88,7 +88,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
-        python-version: [ "3.10", "3.14" ]
+        python-version: [ "3.10" ]
     steps:
       - name: Set Conda platform
         run: |
@@ -184,7 +184,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
-        python-version: [ "3.10", "3.14" ]
+        python-version: [ "3.10" ]
     steps:
       - uses: conda-incubator/setup-miniconda@fc2d68f6413eb2d87b895e92f8584b5b94a10167 # v3.3.0
         with:

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -86,7 +86,7 @@ jobs:
         if: matrix.use_conda_cli == 'true'
         shell: bash -leo pipefail {0}
         run: |
-          conda install pip setuptools editables hatchling hatch-vcs conda-lock --yes
+          conda install conda pip setuptools editables hatchling hatch-vcs conda-lock --yes
           conda uninstall conda-lock --force --yes
           pip install --no-deps --no-build-isolation -e .
       - name: run-test

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -84,12 +84,14 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: install conda-lock
         if: matrix.use_conda_cli == 'true'
+        shell: bash -leo pipefail {0}
         run: |
           conda install pip setuptools conda-lock --yes
           conda uninstall conda-lock --force --yes
           pip install --no-deps --no-build-isolation -e .
       - name: run-test
         if: matrix.use_conda_cli == 'true'
+        shell: bash -leo pipefail {0}
         run: |
           python -m conda lock --log-level=DEBUG --micromamba -f tests/gdal/environment.yml -p $CONDA_PLATFORM
           python -m conda lock render -p $CONDA_PLATFORM

--- a/conda_lock/common.py
+++ b/conda_lock/common.py
@@ -70,7 +70,11 @@ def warn(msg: str) -> None:
     warnings.warn(msg, stacklevel=2)
 
 
-def configure_logger_basic(logger: logging.Logger, level: int | Literal['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'] = logging.INFO) -> None:
+def configure_logger_basic(
+    logger: logging.Logger,
+    level: int
+    | Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"] = logging.INFO,
+) -> None:
     if len(logger.handlers) > 0:
         return
 

--- a/conda_lock/common.py
+++ b/conda_lock/common.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import os
 import pathlib
 import warnings
@@ -66,3 +67,13 @@ def relative_path(source: pathlib.Path, target: pathlib.Path) -> str:
 
 def warn(msg: str) -> None:
     warnings.warn(msg, stacklevel=2)
+
+
+def configure_logger_basic(logger: logging.Logger, level: int = logging.INFO): -> None:
+    if len(logger.handlers) > 0:
+        return
+
+    handler = logging.StreamHandler()
+    handler.setFormatter(logging.Formatter(logging.BASIC_FORMAT, None, "%"))
+    logger.addHandler(handler)
+    logger.setLevel(level)

--- a/conda_lock/common.py
+++ b/conda_lock/common.py
@@ -8,6 +8,7 @@ from collections.abc import Iterable, Mapping, Sequence
 from itertools import chain
 from typing import (
     Any,
+    Literal,
     TypeVar,
 )
 
@@ -69,7 +70,7 @@ def warn(msg: str) -> None:
     warnings.warn(msg, stacklevel=2)
 
 
-def configure_logger_basic(logger: logging.Logger, level: int = logging.INFO) -> None:
+def configure_logger_basic(logger: logging.Logger, level: int | Literal['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'] = logging.INFO) -> None:
     if len(logger.handlers) > 0:
         return
 

--- a/conda_lock/common.py
+++ b/conda_lock/common.py
@@ -69,7 +69,7 @@ def warn(msg: str) -> None:
     warnings.warn(msg, stacklevel=2)
 
 
-def configure_logger_basic(logger: logging.Logger, level: int = logging.INFO): -> None:
+def configure_logger_basic(logger: logging.Logger, level: int = logging.INFO) -> None:
     if len(logger.handlers) > 0:
         return
 

--- a/conda_lock/common.py
+++ b/conda_lock/common.py
@@ -1,5 +1,4 @@
 import json
-import logging
 import os
 import pathlib
 import warnings
@@ -8,7 +7,6 @@ from collections.abc import Iterable, Mapping, Sequence
 from itertools import chain
 from typing import (
     Any,
-    Literal,
     TypeVar,
 )
 
@@ -68,17 +66,3 @@ def relative_path(source: pathlib.Path, target: pathlib.Path) -> str:
 
 def warn(msg: str) -> None:
     warnings.warn(msg, stacklevel=2)
-
-
-def configure_logger_basic(
-    logger: logging.Logger,
-    level: int
-    | Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"] = logging.INFO,
-) -> None:
-    if len(logger.handlers) > 0:
-        return
-
-    handler = logging.StreamHandler()
-    handler.setFormatter(logging.Formatter(logging.BASIC_FORMAT, None, "%"))
-    logger.addHandler(handler)
-    logger.setLevel(level)

--- a/conda_lock/conda_lock.py
+++ b/conda_lock/conda_lock.py
@@ -32,6 +32,7 @@ from ensureconda.resolve import platform_subdir
 from conda_lock import tempdir_manager
 from conda_lock.click_helpers import OrderedGroup
 from conda_lock.common import (
+    configure_logger_basic,
     read_file,
     read_json,
     relative_path,
@@ -1430,7 +1431,7 @@ def lock(
         version: The version of conda-lock used to generate this lock file.
         timestamp: The approximate timestamp of the output file in ISO8601 basic format.
     """
-    logging.basicConfig(level=log_level)
+    configure_logger_basic(logging.getLogger("conda_lock"), level=log_level)
 
     # Set the flag for deleting temporary paths (files/dirs)
     tempdir_manager.state.delete_temp_paths = not preserve_temp_dirs
@@ -1605,7 +1606,7 @@ def click_install(
         sys.exit(1)
 
     """Perform a conda install"""
-    logging.basicConfig(level=log_level)
+    configure_logger_basic(logging.getLogger("conda_lock"), level=log_level)
 
     # Set the flag for deleting temporary paths
     tempdir_manager.state.delete_temp_paths = not preserve_temp_dirs
@@ -1729,7 +1730,7 @@ def render(
     platform: Sequence[str],
 ) -> None:
     """Render multi-platform lockfile into single-platform env or explicit file"""
-    logging.basicConfig(level=log_level)
+    configure_logger_basic(logging.getLogger("conda_lock"), level=log_level)
 
     if pdb:
         sys.excepthook = _handle_exception_post_mortem
@@ -2035,7 +2036,7 @@ def render_lock_spec(  # noqa: C901
             )
         editables.append(EditableDependency(name=name, path=path))
 
-    logging.basicConfig(level=log_level)
+    configure_logger_basic(logging.getLogger("conda_lock"), level=log_level)
 
     # Set Pypi <--> Conda lookup file location
     mapping_url = (

--- a/conda_lock/conda_lock.py
+++ b/conda_lock/conda_lock.py
@@ -32,7 +32,6 @@ from ensureconda.resolve import platform_subdir
 from conda_lock import tempdir_manager
 from conda_lock.click_helpers import OrderedGroup
 from conda_lock.common import (
-    configure_logger_basic,
     read_file,
     read_json,
     relative_path,
@@ -1431,7 +1430,7 @@ def lock(
         version: The version of conda-lock used to generate this lock file.
         timestamp: The approximate timestamp of the output file in ISO8601 basic format.
     """
-    configure_logger_basic(logging.getLogger("conda_lock"), level=log_level)
+    logging.basicConfig(level=log_level, force=True)
 
     # Set the flag for deleting temporary paths (files/dirs)
     tempdir_manager.state.delete_temp_paths = not preserve_temp_dirs
@@ -1606,7 +1605,7 @@ def click_install(
         sys.exit(1)
 
     """Perform a conda install"""
-    configure_logger_basic(logging.getLogger("conda_lock"), level=log_level)
+    logging.basicConfig(level=log_level, force=True)
 
     # Set the flag for deleting temporary paths
     tempdir_manager.state.delete_temp_paths = not preserve_temp_dirs
@@ -1730,7 +1729,7 @@ def render(
     platform: Sequence[str],
 ) -> None:
     """Render multi-platform lockfile into single-platform env or explicit file"""
-    configure_logger_basic(logging.getLogger("conda_lock"), level=log_level)
+    logging.basicConfig(level=log_level, force=True)
 
     if pdb:
         sys.excepthook = _handle_exception_post_mortem
@@ -2036,7 +2035,7 @@ def render_lock_spec(  # noqa: C901
             )
         editables.append(EditableDependency(name=name, path=path))
 
-    configure_logger_basic(logging.getLogger("conda_lock"), level=log_level)
+    logging.basicConfig(level=log_level, force=True)
 
     # Set Pypi <--> Conda lookup file location
     mapping_url = (

--- a/conda_lock/plugin.py
+++ b/conda_lock/plugin.py
@@ -27,7 +27,7 @@ if HAVE_CONDA:
 
 
     @hookimpl
-    def conda_subcommands():
+    def conda_subcommands() -> CondaSubcommand:
         yield CondaSubcommand(
             name="lock",
             summary=("enerate fully reproducible lock files for conda environments."),

--- a/conda_lock/plugin.py
+++ b/conda_lock/plugin.py
@@ -24,8 +24,6 @@ def _execute(args: tuple[str, ...]) -> int | None:
 def conda_subcommands():
     yield CondaSubcommand(
         name="lock",
-        summary=(
-            "enerate fully reproducible lock files for conda environments."
-        ),
+        summary=("enerate fully reproducible lock files for conda environments."),
         action=_execute,
     )

--- a/conda_lock/plugin.py
+++ b/conda_lock/plugin.py
@@ -23,6 +23,7 @@ if HAVE_CONDA:
 
         Lazy import to avoid import-time side effects when not using conda-lock.
         """
+        # code below suggested by AI and appears to work
         from conda_lock.conda_lock import main
 
         return main(args, standalone_mode=False)

--- a/conda_lock/plugin.py
+++ b/conda_lock/plugin.py
@@ -6,6 +6,7 @@ subcommand when this package is installed in the same environment as conda.
 
 from __future__ import annotations
 
+
 try:
     from conda.plugins import hookimpl
     from conda.plugins.types import CondaSubcommand
@@ -16,6 +17,7 @@ except ImportError:
 
 
 if HAVE_CONDA:
+
     def _execute(args: tuple[str, ...]) -> int | None:
         """Dispatch plugin arguments to the lock CLI.
 
@@ -24,7 +26,6 @@ if HAVE_CONDA:
         from conda_lock.__main__ import main
 
         return main()  # TODO: does not accept args for parsing since using click
-
 
     @hookimpl
     def conda_subcommands() -> CondaSubcommand:

--- a/conda_lock/plugin.py
+++ b/conda_lock/plugin.py
@@ -8,8 +8,8 @@ from __future__ import annotations
 
 
 try:
-    from conda.plugins import hookimpl
-    from conda.plugins.types import CondaSubcommand
+    from conda.plugins import hookimpl  # type: ignore
+    from conda.plugins.types import CondaSubcommand  # type: ignore
 
     HAVE_CONDA = True
 except ImportError:

--- a/conda_lock/plugin.py
+++ b/conda_lock/plugin.py
@@ -1,0 +1,31 @@
+"""Conda plugin hooks for conda-lock.
+
+Registers ``conda lock`` so the feedstock tooling is available as a conda
+subcommand when this package is installed in the same environment as conda.
+"""
+
+from __future__ import annotations
+
+from conda.plugins import hookimpl
+from conda.plugins.types import CondaSubcommand
+
+
+def _execute(args: tuple[str, ...]) -> int | None:
+    """Dispatch plugin arguments to the lock CLI.
+
+    Lazy import to avoid import-time side effects when not using conda-lock.
+    """
+    from conda_lock.__main__ import main
+
+    return main()  # TODO: does not accept args for parsing since using click
+
+
+@hookimpl
+def conda_subcommands():
+    yield CondaSubcommand(
+        name="lock",
+        summary=(
+            "enerate fully reproducible lock files for conda environments."
+        ),
+        action=_execute,
+    )

--- a/conda_lock/plugin.py
+++ b/conda_lock/plugin.py
@@ -23,9 +23,9 @@ if HAVE_CONDA:
 
         Lazy import to avoid import-time side effects when not using conda-lock.
         """
-        from conda_lock.__main__ import main
+        from conda_lock.conda_lock import main
 
-        return main()  # TODO: does not accept args for parsing since using click
+        return main(args, standalone_mode=False)
 
     @hookimpl
     def conda_subcommands() -> CondaSubcommand:

--- a/conda_lock/plugin.py
+++ b/conda_lock/plugin.py
@@ -6,24 +6,30 @@ subcommand when this package is installed in the same environment as conda.
 
 from __future__ import annotations
 
-from conda.plugins import hookimpl
-from conda.plugins.types import CondaSubcommand
+try:
+    from conda.plugins import hookimpl
+    from conda.plugins.types import CondaSubcommand
+
+    HAVE_CONDA = True
+except ImportError:
+    HAVE_CONDA = False
 
 
-def _execute(args: tuple[str, ...]) -> int | None:
-    """Dispatch plugin arguments to the lock CLI.
+if HAVE_CONDA:
+    def _execute(args: tuple[str, ...]) -> int | None:
+        """Dispatch plugin arguments to the lock CLI.
 
-    Lazy import to avoid import-time side effects when not using conda-lock.
-    """
-    from conda_lock.__main__ import main
+        Lazy import to avoid import-time side effects when not using conda-lock.
+        """
+        from conda_lock.__main__ import main
 
-    return main()  # TODO: does not accept args for parsing since using click
+        return main()  # TODO: does not accept args for parsing since using click
 
 
-@hookimpl
-def conda_subcommands():
-    yield CondaSubcommand(
-        name="lock",
-        summary=("enerate fully reproducible lock files for conda environments."),
-        action=_execute,
-    )
+    @hookimpl
+    def conda_subcommands():
+        yield CondaSubcommand(
+            name="lock",
+            summary=("enerate fully reproducible lock files for conda environments."),
+            action=_execute,
+        )

--- a/conda_lock/plugin.py
+++ b/conda_lock/plugin.py
@@ -8,8 +8,8 @@ from __future__ import annotations
 
 
 try:
-    from conda.plugins import hookimpl  # type: ignore
-    from conda.plugins.types import CondaSubcommand  # type: ignore
+    from conda.plugins import hookimpl  # type: ignore[unused-ignore]
+    from conda.plugins.types import CondaSubcommand  # type: ignore[unused-ignore]
 
     HAVE_CONDA = True
 except ImportError:

--- a/conda_lock/virtual_package.py
+++ b/conda_lock/virtual_package.py
@@ -14,7 +14,6 @@ from typing import (
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
-from conda_lock.common import configure_logger_basic
 from conda_lock.content_hash_types import (
     HashableVirtualPackage,
     HashableVirtualPackageRepresentation,
@@ -318,7 +317,7 @@ def virtual_package_repo_from_specification(
 
 
 if __name__ == "__main__":
-    configure_logger_basic(logging.getLogger("conda_lock"), level=logging.DEBUG)
+    logging.basicConfig(level=logging.DEBUG, force=True)
     fil = (
         pathlib.Path(__file__).parent.parent
         / "tests"

--- a/conda_lock/virtual_package.py
+++ b/conda_lock/virtual_package.py
@@ -14,6 +14,7 @@ from typing import (
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
+from conda_lock.common import configure_logger_basic
 from conda_lock.content_hash_types import (
     HashableVirtualPackage,
     HashableVirtualPackageRepresentation,
@@ -317,7 +318,7 @@ def virtual_package_repo_from_specification(
 
 
 if __name__ == "__main__":
-    logging.basicConfig(level=logging.DEBUG)
+    configure_logger_basic(logging.getLogger("conda_lock"), level=logging.DEBUG)
     fil = (
         pathlib.Path(__file__).parent.parent
         / "tests"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,6 +94,9 @@ dependencies = [
 [project.scripts]
 conda-lock = "conda_lock:main"
 
+[project.entry-points.conda]
+conda-lock = "conda_lock.plugin"
+
 [project.urls]
 Homepage = "https://github.com/conda/conda-lock"
 Repository = "https://github.com/conda/conda-lock"


### PR DESCRIPTION


<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

The latest conda versions switched to plugin hooks for custom subcommands (e.g., `conda lock`) and as of conda 26.3, the old interface was deprecated. This PR adds the proper plugin hooks.

To Do:

- [x] add plugin hooks
    - [x] add basic code for the hook
    - [x] figure out how to pass argv to click per the todo item
- [x] adjust logging config so we don't rely on configuring the root logger
- [x] add tests w/ conda in the python env to ensure the new plugin hooks work as expected

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->



<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/.github/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/.github/blob/main/CONTRIBUTING.md -->


closes #904 