### PR TITLE
chore: group Renovate non-major updates and throttle PR bursts

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,8 +1,10 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base"
+    "config:recommended"
   ],
+  "prConcurrentLimit": 3,
+  "prHourlyLimit": 2,
   "packageRules": [
     {
       "matchManagers": ["setup-cfg", "pip_requirements"],
@@ -12,6 +14,10 @@
     {
       "matchManagers": ["github-actions"],
       "groupName": "GitHub Actions"
+    },
+    {
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "non-major dependencies"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Group all minor/patch dependency updates into a single rolling **non-major dependencies** PR. Majors still get individual PRs since they tend to need code changes (cf. #911 for `installer 1.x`).
- Cap concurrent open Renovate PRs at **3** and limit new-PR creation to **2 per hour** so a burst of bumps can't saturate the test matrix.
- Switch from the deprecated `config:base` preset to `config:recommended`.

## Motivation

Renovate currently opens one PR per dependency bump, each kicking off the full ~26-shard test matrix. Today a small burst (dulwich 0.x, dulwich v1, virtualenv v21) queued behind the post-#911 main run and stalled CI for ~hour, with multiple shards never starting.

## Test plan

- [ ] Renovate's next dependency-dashboard refresh produces a single grouped PR for any pending minor/patch bumps.
- [ ] Major-version Renovate PRs (e.g. dulwich v1) continue to land as individual PRs.
- [ ] Concurrent open Renovate PRs cap at 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)