### PR TITLE
Merge duplicate dependency specs

### DIFF
--- a/conda_lock/conda_solver.py
+++ b/conda_lock/conda_solver.py
@@ -127,7 +127,7 @@ def solve_conda(
     # extract dependencies from package plan
     planned = {}
     for action in dry_run_install["actions"]["FETCH"]:
-        dependency_specs = {}
+        dependency_specs: dict[str, list[MatchSpec]] = {}
         for dep in action.get("depends") or []:
             matchspec = MatchSpec(dep)  # pyright: ignore[reportArgumentType]
             dependency_specs.setdefault(matchspec.name, []).append(matchspec)

--- a/conda_lock/conda_solver.py
+++ b/conda_lock/conda_solver.py
@@ -134,7 +134,11 @@ def solve_conda(
 
         dependencies = {}
         for name, matchspecs in dependency_specs.items():
-            merged_matchspec = MatchSpec.merge(matchspecs)[0]
+            merged_matchspec = (
+                matchspecs[0]
+                if len(matchspecs) == 1
+                else MatchSpec.merge(matchspecs)[0]
+            )
             dependencies[name] = (
                 merged_matchspec.version.spec_str
                 if merged_matchspec.version is not None

--- a/conda_lock/conda_solver.py
+++ b/conda_lock/conda_solver.py
@@ -127,14 +127,19 @@ def solve_conda(
     # extract dependencies from package plan
     planned = {}
     for action in dry_run_install["actions"]["FETCH"]:
-        dependencies = {}
+        dependency_specs = {}
         for dep in action.get("depends") or []:
             matchspec = MatchSpec(dep)  # pyright: ignore[reportArgumentType]
-            name = matchspec.name
-            version = (
-                matchspec.version.spec_str if matchspec.version is not None else ""
+            dependency_specs.setdefault(matchspec.name, []).append(matchspec)
+
+        dependencies = {}
+        for name, matchspecs in dependency_specs.items():
+            merged_matchspec = MatchSpec.merge(matchspecs)[0]
+            dependencies[name] = (
+                merged_matchspec.version.spec_str
+                if merged_matchspec.version is not None
+                else ""
             )
-            dependencies[name] = version
 
         locked_dependency = LockedDependency(
             name=action["name"],

--- a/tests/test_conda_solver.py
+++ b/tests/test_conda_solver.py
@@ -1,0 +1,55 @@
+from conda_lock import conda_solver
+from conda_lock.lookup import DEFAULT_MAPPING_URL
+from conda_lock.models.channel import Channel
+from conda_lock.models.lock_spec import VersionedDependency
+
+
+def test_solve_conda_merges_duplicate_dependency_specs(monkeypatch) -> None:
+    for depends in [
+        ["python", "python >=3.10"],
+        ["python >=3.10", "python"],
+    ]:
+
+        def solve_specs_for_arch(*args, **kwargs):
+            return {
+                "actions": {
+                    "FETCH": [
+                        {
+                            "name": "python",
+                            "version": "3.13.0",
+                            "depends": [],
+                            "url": "https://conda.anaconda.org/conda-forge/linux-64/python-3.13.0-0.conda",
+                            "md5": "1",
+                        },
+                        {
+                            "name": "babel",
+                            "version": "2.18.0",
+                            "depends": depends,
+                            "url": "https://conda.anaconda.org/conda-forge/noarch/babel-2.18.0-pyhcf101f3_1.conda",
+                            "md5": "2",
+                        },
+                    ],
+                },
+            }
+
+        monkeypatch.setattr(conda_solver, "solve_specs_for_arch", solve_specs_for_arch)
+
+        planned = conda_solver.solve_conda(
+            conda="micromamba",
+            specs={
+                "babel": VersionedDependency(
+                    name="babel",
+                    version="",
+                    manager="conda",
+                    category="main",
+                    extras=[],
+                ),
+            },
+            locked={},
+            update=[],
+            platform="linux-64",
+            channels=[Channel.from_string("conda-forge")],
+            mapping_url=DEFAULT_MAPPING_URL,
+        )
+
+        assert planned["babel"].dependencies["python"] == ">=3.10"


### PR DESCRIPTION
Some solver results contain duplicate dependency specs for the same package, e.g. both `python` and `python >=3.10` for a noarch package. The current dict assignment keeps whichever one appears last, so equivalent solves can produce different lock metadata.

I version-control a few hundred thousand lines of generated conda lock files that change relatively frequently, so this ordering difference creates a lot of review noise.

A common noisy diff looks like this:

```diff
 dependencies:
-  python: '>=3.10'
+  python: ''
```

That happens when solver output contains the same dependency twice in different orders, such as:

```text
linux-64:   ["python >=3.10", "python"]
osx-arm64: ["python", "python >=3.10"]
```

After merging duplicate `MatchSpec`s first, both orders produce the more constrained and stable result:

```yaml
dependencies:
  python: '>=3.10'
```
