### PR TITLE
pass "extras" through to dependencies when reading from pyproject.toml

### DIFF
--- a/conda_lock/pypi_solver.py
+++ b/conda_lock/pypi_solver.py
@@ -331,6 +331,7 @@ def get_dependency(dep: lock_spec.Dependency) -> PoetryDependency:
             vcs=dep.vcs,
             source=dep.source,
             rev=dep.rev,
+            extras=dep.extras,
         )
     elif isinstance(dep, lock_spec.PathDependency):
         if dep.is_directory:

--- a/conda_lock/src_parser/pyproject_toml.py
+++ b/conda_lock/src_parser/pyproject_toml.py
@@ -293,6 +293,7 @@ def parse_poetry_pyproject_toml(
                 dependencies.append(
                     VCSDependency(
                         name=name,
+                        extras=extras,
                         markers=markers,
                         source=url,
                         manager=manager,
@@ -577,6 +578,7 @@ def parse_python_requirement(
             source=url,
             manager=manager,
             category=category,
+            extras=extras,
             vcs="git",
             rev=rev,
             markers=markers,


### PR DESCRIPTION
Fixes #925 

Connects the dots between the `pyproject_toml` source parser and the `pypi_solver` so that extras coupled with VCS sources make it into the solution.